### PR TITLE
Tech component fails due to missing requirements

### DIFF
--- a/custom_components/tech/manifest.json
+++ b/custom_components/tech/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tech Controllers",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tech",
-  "requirements": ["tech"],
+  "requirements": [],
   "dependencies": [],
   "codeowners": [
     "@mariusz.ostoja-swierczynski"


### PR DESCRIPTION
Tech custom-component fails to initialize due to missing requirements (as defined in manifest.json#requirements): it requires itself.