### PR TITLE
✨ Move most sensors under Diagnostics

### DIFF
--- a/custom_components/tech/binary_sensor.py
+++ b/custom_components/tech/binary_sensor.py
@@ -2,7 +2,13 @@
 import logging
 
 from homeassistant.components import binary_sensor
-from homeassistant.const import CONF_PARAMS, CONF_TYPE, STATE_OFF, STATE_ON
+from homeassistant.const import (
+    CONF_PARAMS,
+    CONF_TYPE,
+    STATE_OFF,
+    STATE_ON,
+    EntityCategory,
+)
 
 from . import TechCoordinator, assets
 from .const import (
@@ -53,6 +59,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 class TileBinarySensor(TileEntity, binary_sensor.BinarySensorEntity):
     """Representation of a TileBinarySensor."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def get_state(self, device):
         """Get the state of the device."""

--- a/custom_components/tech/sensor.py
+++ b/custom_components/tech/sensor.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     PERCENTAGE,
     STATE_OFF,
     STATE_ON,
+    EntityCategory,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -592,6 +593,8 @@ class TechHumiditySensor(CoordinatorEntity, SensorEntity):
 class ZoneSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Zone Sensor."""
 
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
     def __init__(
         self, device: Dict, coordinator: TechCoordinator, config_entry: ConfigEntry
     ):
@@ -818,6 +821,8 @@ class ZoneOutsideTempTile(ZoneSensor):
 
 class TileSensor(TileEntity, CoordinatorEntity):
     """Representation of a TileSensor."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def get_state(self, device):
         """Get the state of the device."""


### PR DESCRIPTION
Moves most sensors to DIAGNOSTIC Entity Category as they are not actionable.