### PR TITLE
Tweaking CI

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,15 @@ jobs:
     name: Prepare release asset
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
+      - name: Checkout repository
         uses: actions/checkout@v4
-      - name: "Set manifest version number"
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Set manifest version number
         run: |
-          python3 ${{ github.workspace }}/.github/scripts/update_hacs_manifest.py --version ${{ github.ref_name }}
+          python ${{ github.workspace }}/.github/scripts/update_hacs_manifest.py --version ${{ github.ref_name }}
       - name: Create zip
         run: |
           cd custom_components/tech

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Run Tech API tests
 on:
   push:
   schedule:
-    - cron: '0 4 * * *'
+    - cron: "0 4 * * *"
   workflow_dispatch:
 
 jobs:
@@ -12,14 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
       - uses: MathRobin/timezone-action@v1.1
         with:
           timezoneLinux: "Europe/Berlin"
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -30,11 +31,12 @@ jobs:
           pip install -r requirements_test_api.txt
       - name: Install dependencies
         run: pip install pytest pytest-md pytest-emoji
-      - uses: pavelzw/pytest-action@v2
+      - name: Run tests
+        uses: pavelzw/pytest-action@v2
         with:
           emoji: true
           verbose: true
           job-summary: true
-          custom-arguments: 'tests/tests_api --cov-report=term-missing --cov=custom_components.tech.tech tests/'
+          custom-arguments: "tests/tests_api --cov-report=term-missing --cov=custom_components.tech.tech tests/"
           click-to-expand: true
-          report-title: 'Tech API test report'
+          report-title: "Tech API test report"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -7,17 +7,25 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate-hassfest:
+    name: Validate Hassfest
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v4"
-      - uses: home-assistant/actions/hassfest@master
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Hassfest validation
+        uses: home-assistant/actions/hassfest@master
   validate-hacs:
+    name: Validate HACS
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v4"
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: HACS validation
-        uses: "hacs/action@main"
+        uses: hacs/action@main
         with:
           category: "integration"


### PR DESCRIPTION
Tweaking CI:
- added names to steps and jobs
- set Python version in release workflow
- tests will be running on Python 3.12 as 3.11 is in deprecation path in Home assistant
- removed release drafter action from pull requests operations as I doubt we want to draft release basing also on PRs which potentially will be never merged
