### PR TITLE
change to fix eventual consistency

### DIFF
--- a/custom_components/tech/climate.py
+++ b/custom_components/tech/climate.py
@@ -106,7 +106,13 @@ class TechThermostat(ClimateEntity, CoordinatorEntity):
         """
         # Update target temperature
         if device[CONF_ZONE]["setTemperature"] is not None:
-            self._target_temperature = device[CONF_ZONE]["setTemperature"] / 10
+            if device[CONF_ZONE]["duringChange"] is False:
+                self._target_temperature = device[CONF_ZONE]["setTemperature"] / 10
+            else:
+                _LOGGER.debug(
+                    "Zone ID %s is duringChange so ignore to update target temperature",
+                    device[CONF_ZONE]["id"],
+                )
         else:
             self._target_temperature = None
 
@@ -235,6 +241,8 @@ class TechThermostat(ClimateEntity, CoordinatorEntity):
             await self._coordinator.api.set_const_temp(
                 self._udid, self._id, temperature
             )
+            self._target_temperature = temperature
+            await self.coordinator.async_request_refresh()
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""


### PR DESCRIPTION
Closes #70 

This is extending logic during set temperature function. So I am doing two things:
- target temperature of climate entity is updated only when entity reflecting zone is not `duringChange` state (which reflect on Tech API that change was triggered but not finished syncing with controller). In that case target temperature of climate entity will be not updated on function `update_properties` and proper debug log will be showing zone id is `duringChange`

- on `async_set_temperature` function I am setting target temparature property to temperature which was requested in setTemperature send to tech API, after that I am triggering refresh of coordinator. My testing showed `duringChange` phase takes around 15-30 seconds, so when update inteval is 60 seconds it could take 15-90 seconds (so in worst case require 2 iterations of sync update via coordinator) to reflect real value of `setTemperature` in climate entity. So update target temperature (`setTemperature` attribute) I am forcing update of coordinator via `await self.coordinator.async_request_refresh()` and then second iteration should return real values from API. This logic will make update for real entity more predictable (it will always happen in second iteration in 60 seconds)

Tests on my environment showed it is working as planned.

Logs from this:
```sh
2024-04-23 20:09:25.475 DEBUG (MainThread) [custom_components.tech.tech] Updating zones cache for controller: 47a0aaaaaaacbbbbbbbbbbbbbbbbbbb
2024-04-23 20:09:25.476 DEBUG (MainThread) [custom_components.tech.tech] Updating tiles cache for controller: 47a0aaaaaaacbbbbbbbbbbbbbbbbbbb
2024-04-23 20:09:25.476 DEBUG (MainThread) [custom_components.tech] Finished fetching tech data in 0.174 seconds (success: True)
2024-04-23 20:09:43.453 DEBUG (MainThread) [custom_components.tech.climate] Salon: Setting temperature to 20.299999999999997
2024-04-23 20:09:43.453 DEBUG (MainThread) [custom_components.tech.tech] Setting zone constant temperature...
2024-04-23 20:09:43.453 DEBUG (MainThread) [custom_components.tech.tech] {'mode': {'id': 9072, 'parentId': 9070, 'mode': 'constantTemp', 'constTempTime': 60, 'setTemperature': 202, 'scheduleIndex': 0}}
2024-04-23 20:09:43.453 DEBUG (MainThread) [custom_components.tech.tech] Sending POST request: https://emodul.eu/api/v1/users/111111111/modules/47a0aaaaaaacbbbbbbbbbbbbbbbbbbb/zones
2024-04-23 20:09:43.714 DEBUG (MainThread) [custom_components.tech.tech] {'message': 'Data has been sent correctly'}
2024-04-23 20:09:43.715 DEBUG (MainThread) [custom_components.tech] Updating data for: Ogrzewanie
2024-04-23 20:09:43.716 DEBUG (MainThread) [custom_components.tech.tech] Updating module zones & tiles cache... 47a0aaaaaaacbbbbbbbbbbbbbbbbbbb
2024-04-23 20:09:43.716 DEBUG (MainThread) [custom_components.tech.tech] Getting module data...  47a0aaaaaaacbbbbbbbbbbbbbbbbbbb,  111111111
2024-04-23 20:09:43.716 DEBUG (MainThread) [custom_components.tech.tech] Sending GET request: https://emodul.eu/api/v1/users/111111111/modules/47a0aaaaaaacbbbbbbbbbbbbbbbbbbb
2024-04-23 20:09:43.932 DEBUG (MainThread) [custom_components.tech.tech] Updating zones cache for controller: 47a0aaaaaaacbbbbbbbbbbbbbbbbbbb
2024-04-23 20:09:43.932 DEBUG (MainThread) [custom_components.tech.tech] Updating tiles cache for controller: 47a0aaaaaaacbbbbbbbbbbbbbbbbbbb
2024-04-23 20:09:43.932 DEBUG (MainThread) [custom_components.tech] Finished fetching tech data in 0.217 seconds (success: True)
2024-04-23 20:09:43.933 DEBUG (MainThread) [custom_components.tech.climate] Zone ID 9070 is duringChange so ignore to update target temperature
```