### PR TITLE
✨ add integration support for Tech API supported languages

### DIFF
--- a/custom_components/tech/translations/cs.json
+++ b/custom_components/tech/translations/cs.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Zařízení již nakonfigurováno",
+            "no_modules": "Nebyly detekovány žádné moduly nebo nebyly vybrány"
+        },
+        "error": {
+            "cannot_connect": "Nelze se připojit k Tech API.",
+            "invalid_auth": "Neplatné uživatelské jméno nebo heslo!",
+            "unknown": "Neznámá chyba. Prosím, zkuste to znovu nebo nahlaste chybu na ..."
+        },
+        "step": {
+            "user": {
+                "title": "Přihlášení k Tech Controllers",
+                "description": "Prosím, zadejte své přihlašovací údaje pro službu emodul.eu nebo emodul.pl.",
+                "data": {
+                    "password": "Heslo",
+                    "username": "Uživatelské jméno"
+                }
+            },
+            "select_controllers": {
+                "title": "Výběr ovladačů",
+                "description": "Prosím, vyberte ovladače, které chcete integrovat.",
+                "data": {
+                    "controllers": "Ovladače k importu",
+                    "include_hub_in_name": "Zahrnout název hubu (ovladače) do názvů entit"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "temperature_entity": {
+                "name": "{entity_name} Teplota"
+            },
+            "battery_entity": {
+                "name": "{entity_name} Baterie"
+            },
+            "humidity_entity": {
+                "name": "Vlhkost"
+            },
+            "actuator_entity": {
+                "name": "Aktuátor {actuator_number}"
+            },
+            "window_sensor_entity": {
+                "name": "Okno {window_number}"
+            },
+            "ext_temperature_entity": {
+                "name": "Externí teplota"
+            },
+            "signal_strength_entity": {
+                "name": "{entity_name} Síla signálu"
+            }
+        }
+    },
+    "title": "Tech Controllers"
+}

--- a/custom_components/tech/translations/de.json
+++ b/custom_components/tech/translations/de.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Gerät bereits konfiguriert",
+            "no_modules": "Keine Module erkannt oder ausgewählt"
+        },
+        "error": {
+            "cannot_connect": "Keine Verbindung zur Tech API möglich.",
+            "invalid_auth": "Ungültiger Benutzername oder Passwort!",
+            "unknown": "Unbekannter Fehler. Bitte versuchen Sie es erneut oder melden Sie den Fehler an ..."
+        },
+        "step": {
+            "user": {
+                "title": "Tech Controllers Anmeldung",
+                "description": "Bitte geben Sie Ihre Anmeldedaten für den emodul.eu oder emodul.pl Service ein.",
+                "data": {
+                    "password": "Passwort",
+                    "username": "Benutzername"
+                }
+            },
+            "select_controllers": {
+                "title": "Controller-Auswahl",
+                "description": "Bitte wählen Sie die Controller aus, die Sie integrieren möchten.",
+                "data": {
+                    "controllers": "Zu importierende Controller",
+                    "include_hub_in_name": "Hub (Controller) Namen in Entitätsnamen einbeziehen"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "temperature_entity": {
+                "name": "{entity_name} Temperatur"
+            },
+            "battery_entity": {
+                "name": "{entity_name} Batterie"
+            },
+            "humidity_entity": {
+                "name": "Luftfeuchtigkeit"
+            },
+            "actuator_entity": {
+                "name": "Aktuator {actuator_number}"
+            },
+            "window_sensor_entity": {
+                "name": "Fenster {window_number}"
+            },
+            "ext_temperature_entity": {
+                "name": "Externe Temperatur"
+            },
+            "signal_strength_entity": {
+                "name": "{entity_name} Signalstärke"
+            }
+        }
+    },
+    "title": "Tech Controllers"
+}

--- a/custom_components/tech/translations/es.json
+++ b/custom_components/tech/translations/es.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Dispositivo ya configurado",
+            "no_modules": "No se detectaron módulos o no se seleccionaron"
+        },
+        "error": {
+            "cannot_connect": "No se puede conectar a la API de Tech.",
+            "invalid_auth": "¡Nombre de usuario o contraseña no válidos!",
+            "unknown": "Error desconocido. Por favor, inténtelo de nuevo o informe del error a ..."
+        },
+        "step": {
+            "user": {
+                "title": "Inicio de sesión en Tech Controllers",
+                "description": "Por favor, ingrese sus credenciales para el servicio emodul.eu o emodul.pl.",
+                "data": {
+                    "password": "Contraseña",
+                    "username": "Nombre de usuario"
+                }
+            },
+            "select_controllers": {
+                "title": "Selección de controladores",
+                "description": "Por favor, seleccione los controladores que desea integrar.",
+                "data": {
+                    "controllers": "Controladores a importar",
+                    "include_hub_in_name": "Incluir nombre del concentrador (controlador) en los nombres de las entidades"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "temperature_entity": {
+                "name": "Temperatura de {entity_name}"
+            },
+            "battery_entity": {
+                "name": "Batería de {entity_name}"
+            },
+            "humidity_entity": {
+                "name": "Humedad"
+            },
+            "actuator_entity": {
+                "name": "Actuador {actuator_number}"
+            },
+            "window_sensor_entity": {
+                "name": "Ventana {window_number}"
+            },
+            "ext_temperature_entity": {
+                "name": "Temperatura externa"
+            },
+            "signal_strength_entity": {
+                "name": "Intensidad de señal de {entity_name}"
+            }
+        }
+    },
+    "title": "Controladores Tech"
+}

--- a/custom_components/tech/translations/et.json
+++ b/custom_components/tech/translations/et.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Seade on juba konfigureeritud",
+            "no_modules": "Ühtegi moodulit ei tuvastatud ega valitud"
+        },
+        "error": {
+            "cannot_connect": "Ei saa ühendust Tech API-ga.",
+            "invalid_auth": "Vigane kasutajanimi või parool!",
+            "unknown": "Tundmatu viga. Palun proovige uuesti või teavitage veast ..."
+        },
+        "step": {
+            "user": {
+                "title": "Tech Controllersi sisselogimine",
+                "description": "Palun sisestage oma volitused emodul.eu või emodul.pl teenusesse.",
+                "data": {
+                    "password": "Parool",
+                    "username": "Kasutajanimi"
+                }
+            },
+            "select_controllers": {
+                "title": "Kontrollerite valik",
+                "description": "Palun valige kontrollerid, mida soovite integreerida.",
+                "data": {
+                    "controllers": "Imporditavad kontrollerid",
+                    "include_hub_in_name": "Kaasa hubi (kontrolleri) nimi üksuste nimedes"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "temperature_entity": {
+                "name": "{entity_name} Temperatuur"
+            },
+            "battery_entity": {
+                "name": "{entity_name} Aku"
+            },
+            "humidity_entity": {
+                "name": "Niiskus"
+            },
+            "actuator_entity": {
+                "name": "Aktuaator {actuator_number}"
+            },
+            "window_sensor_entity": {
+                "name": "Aken {window_number}"
+            },
+            "ext_temperature_entity": {
+                "name": "Väline temperatuur"
+            },
+            "signal_strength_entity": {
+                "name": "{entity_name} Signaali tugevus"
+            }
+        }
+    },
+    "title": "Tech Controllers"
+}

--- a/custom_components/tech/translations/fr.json
+++ b/custom_components/tech/translations/fr.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Appareil déjà configuré",
+            "no_modules": "Aucun module détecté ou sélectionné"
+        },
+        "error": {
+            "cannot_connect": "Impossible de se connecter à l'API Tech.",
+            "invalid_auth": "Nom d'utilisateur ou mot de passe invalide !",
+            "unknown": "Erreur inconnue. Veuillez réessayer ou signaler le bogue à ..."
+        },
+        "step": {
+            "user": {
+                "title": "Connexion aux contrôleurs Tech",
+                "description": "Veuillez entrer vos identifiants pour le service emodul.eu ou emodul.pl.",
+                "data": {
+                    "password": "Mot de passe",
+                    "username": "Nom d'utilisateur"
+                }
+            },
+            "select_controllers": {
+                "title": "Sélection du contrôleur",
+                "description": "Veuillez sélectionner les contrôleurs que vous souhaitez intégrer.",
+                "data": {
+                    "controllers": "Contrôleurs à importer",
+                    "include_hub_in_name": "Inclure le nom du hub (contrôleur) dans les noms des entités"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "temperature_entity": {
+                "name": "Température {entity_name}"
+            },
+            "battery_entity": {
+                "name": "Batterie {entity_name}"
+            },
+            "humidity_entity": {
+                "name": "Humidité"
+            },
+            "actuator_entity": {
+                "name": "Actionneur {actuator_number}"
+            },
+            "window_sensor_entity": {
+                "name": "Fenêtre {window_number}"
+            },
+            "ext_temperature_entity": {
+                "name": "Température externe"
+            },
+            "signal_strength_entity": {
+                "name": "Force du signal {entity_name}"
+            }
+        }
+    },
+    "title": "Contrôleurs Tech"
+}

--- a/custom_components/tech/translations/hr.json
+++ b/custom_components/tech/translations/hr.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Uređaj već konfiguriran",
+            "no_modules": "Nisu otkriveni ili odabrani moduli"
+        },
+        "error": {
+            "cannot_connect": "Nemoguće povezivanje s Tech API-jem.",
+            "invalid_auth": "Neispravno korisničko ime ili lozinka!",
+            "unknown": "Nepoznata pogreška. Molimo pokušajte ponovno ili prijavite grešku na ..."
+        },
+        "step": {
+            "user": {
+                "title": "Prijava na Tech Controllers",
+                "description": "Unesite svoje podatke za prijavu na uslugu emodul.eu ili emodul.pl.",
+                "data": {
+                    "password": "Lozinka",
+                    "username": "Korisničko ime"
+                }
+            },
+            "select_controllers": {
+                "title": "Odabir kontrolera",
+                "description": "Odaberite kontrolere koje želite integrirati.",
+                "data": {
+                    "controllers": "Kontroleri za uvoz",
+                    "include_hub_in_name": "Uključi naziv glavnog uređaja (kontrolera) u nazive entiteta"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "temperature_entity": {
+                "name": "{entity_name} Temperatura"
+            },
+            "battery_entity": {
+                "name": "{entity_name} Baterija"
+            },
+            "humidity_entity": {
+                "name": "Vlažnost"
+            },
+            "actuator_entity": {
+                "name": "Aktuator {actuator_number}"
+            },
+            "window_sensor_entity": {
+                "name": "Prozor {window_number}"
+            },
+            "ext_temperature_entity": {
+                "name": "Vanjska temperatura"
+            },
+            "signal_strength_entity": {
+                "name": "{entity_name} Jačina signala"
+            }
+        }
+    },
+    "title": "Tech Controllers"
+}

--- a/custom_components/tech/translations/hu.json
+++ b/custom_components/tech/translations/hu.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Az eszköz már konfigurálva van",
+            "no_modules": "Nem találhatóak modulok vagy nincsenek kiválasztva"
+        },
+        "error": {
+            "cannot_connect": "Nem sikerült kapcsolódni a Tech API-hoz.",
+            "invalid_auth": "Érvénytelen felhasználónév vagy jelszó!",
+            "unknown": "Ismeretlen hiba. Kérjük, próbálja újra, vagy jelentse a hibát a következő címre: ..."
+        },
+        "step": {
+            "user": {
+                "title": "Tech Controllers Bejelentkezés",
+                "description": "Kérjük, adja meg a hitelesítő adatait az emodul.eu vagy emodul.pl szolgáltatáshoz.",
+                "data": {
+                    "password": "Jelszó",
+                    "username": "Felhasználónév"
+                }
+            },
+            "select_controllers": {
+                "title": "Válassza ki a vezérlőket",
+                "description": "Kérjük, válassza ki az integrálni kívánt vezérlőket.",
+                "data": {
+                    "controllers": "Importálni kívánt vezérlők",
+                    "include_hub_in_name": "A hub (vezérlő) nevének belefoglalása az entitásnevekbe"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "temperature_entity": {
+                "name": "{entity_name} Hőmérséklet"
+            },
+            "battery_entity": {
+                "name": "{entity_name} Akkumulátor"
+            },
+            "humidity_entity": {
+                "name": "Páratartalom"
+            },
+            "actuator_entity": {
+                "name": "Aktuátor {actuator_number}"
+            },
+            "window_sensor_entity": {
+                "name": "Ablak {window_number}"
+            },
+            "ext_temperature_entity": {
+                "name": "Külső hőmérséklet"
+            },
+            "signal_strength_entity": {
+                "name": "{entity_name} Jel erősség"
+            }
+        }
+    },
+    "title": "Tech Controllers"
+}

--- a/custom_components/tech/translations/it.json
+++ b/custom_components/tech/translations/it.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Dispositivo già configurato",
+            "no_modules": "Nessun modulo rilevato o selezionato"
+        },
+        "error": {
+            "cannot_connect": "Impossibile connettersi all'API di Tech.",
+            "invalid_auth": "Nome utente o password non validi!",
+            "unknown": "Errore sconosciuto. Riprova o segnala il bug a ..."
+        },
+        "step": {
+            "user": {
+                "title": "Accesso ai controller Tech",
+                "description": "Inserisci le tue credenziali per il servizio emodul.eu o emodul.pl.",
+                "data": {
+                    "password": "Password",
+                    "username": "Nome utente"
+                }
+            },
+            "select_controllers": {
+                "title": "Selezione del controller",
+                "description": "Seleziona i controller che desideri integrare.",
+                "data": {
+                    "controllers": "Controller da importare",
+                    "include_hub_in_name": "Includi il nome dell'hub (controller) nei nomi delle entità"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "temperature_entity": {
+                "name": "{entity_name} Temperatura"
+            },
+            "battery_entity": {
+                "name": "{entity_name} Batteria"
+            },
+            "humidity_entity": {
+                "name": "Umidità"
+            },
+            "actuator_entity": {
+                "name": "Attuatore {actuator_number}"
+            },
+            "window_sensor_entity": {
+                "name": "Finestra {window_number}"
+            },
+            "ext_temperature_entity": {
+                "name": "Temperatura esterna"
+            },
+            "signal_strength_entity": {
+                "name": "{entity_name} Intensità del segnale"
+            }
+        }
+    },
+    "title": "Controller Tech"
+}

--- a/custom_components/tech/translations/lt.json
+++ b/custom_components/tech/translations/lt.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Įrenginys jau sukonfigūruotas",
+            "no_modules": "Nerasta modulių arba nepasirinkta"
+        },
+        "error": {
+            "cannot_connect": "Nepavyksta prisijungti prie Tech API.",
+            "invalid_auth": "Neteisingas prisijungimo vardas arba slaptažodis!",
+            "unknown": "Nežinoma klaida. Bandykite dar kartą arba praneškite apie klaidą ..."
+        },
+        "step": {
+            "user": {
+                "title": "Tech Valdiklių Prisijungimas",
+                "description": "Įveskite savo prisijungimo duomenis į emodul.eu arba emodul.pl paslaugą.",
+                "data": {
+                    "password": "Slaptažodis",
+                    "username": "Prisijungimo vardas"
+                }
+            },
+            "select_controllers": {
+                "title": "Valdiklių pasirinkimas",
+                "description": "Pasirinkite valdiklius, kuriuos norite integruoti.",
+                "data": {
+                    "controllers": "Valdikliai importavimui",
+                    "include_hub_in_name": "Įtraukti centrinį mazgą (valdiklį) į sąvybių pavadinimus"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "temperature_entity": {
+                "name": "{entity_name} Temperatūra"
+            },
+            "battery_entity": {
+                "name": "{entity_name} Baterija"
+            },
+            "humidity_entity": {
+                "name": "Drėgmė"
+            },
+            "actuator_entity": {
+                "name": "Veikiklis {actuator_number}"
+            },
+            "window_sensor_entity": {
+                "name": "Langas {window_number}"
+            },
+            "ext_temperature_entity": {
+                "name": "Išorinė temperatūra"
+            },
+            "signal_strength_entity": {
+                "name": "{entity_name} Signalas"
+            }
+        }
+    },
+    "title": "Tech Valdikliai"
+}

--- a/custom_components/tech/translations/nl.json
+++ b/custom_components/tech/translations/nl.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Apparaat is al geconfigureerd",
+            "no_modules": "Geen modules gedetecteerd of geselecteerd"
+        },
+        "error": {
+            "cannot_connect": "Kan geen verbinding maken met Tech API.",
+            "invalid_auth": "Ongeldige gebruikersnaam of wachtwoord!",
+            "unknown": "Onbekende fout. Probeer het opnieuw of meld de bug aan ..."
+        },
+        "step": {
+            "user": {
+                "title": "Tech Controllers Login",
+                "description": "Voer uw inloggegevens in voor de emodul.eu of emodul.pl service.",
+                "data": {
+                    "password": "Wachtwoord",
+                    "username": "Gebruikersnaam"
+                }
+            },
+            "select_controllers": {
+                "title": "Controller selectie",
+                "description": "Selecteer de controllers die u wilt integreren.",
+                "data": {
+                    "controllers": "Te importeren controllers",
+                    "include_hub_in_name": "Inclusief hub (controller) naam in entiteitnamen"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "temperature_entity": {
+                "name": "{entity_name} Temperatuur"
+            },
+            "battery_entity": {
+                "name": "{entity_name} Batterij"
+            },
+            "humidity_entity": {
+                "name": "Luchtvochtigheid"
+            },
+            "actuator_entity": {
+                "name": "Actuator {actuator_number}"
+            },
+            "window_sensor_entity": {
+                "name": "Raam {window_number}"
+            },
+            "ext_temperature_entity": {
+                "name": "Externe temperatuur"
+            },
+            "signal_strength_entity": {
+                "name": "{entity_name} Signaalsterkte"
+            }
+        }
+    },
+    "title": "Tech Controllers"
+}

--- a/custom_components/tech/translations/ro.json
+++ b/custom_components/tech/translations/ro.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Dispozitiv deja configurat",
+            "no_modules": "Nu au fost detectate sau selectate module"
+        },
+        "error": {
+            "cannot_connect": "Nu se poate conecta la API-ul Tech.",
+            "invalid_auth": "Nume de utilizator sau parolă nevalidă!",
+            "unknown": "Eroare necunoscută. Vă rugăm să încercați din nou sau raportați eroarea la ..."
+        },
+        "step": {
+            "user": {
+                "title": "Autentificare Tech Controllers",
+                "description": "Vă rugăm să introduceți datele de autentificare pentru serviciul emodul.eu sau emodul.pl.",
+                "data": {
+                    "password": "Parolă",
+                    "username": "Nume de utilizator"
+                }
+            },
+            "select_controllers": {
+                "title": "Selectare controlere",
+                "description": "Vă rugăm să selectați controlerele pe care doriți să le integrați.",
+                "data": {
+                    "controllers": "Controlere de importat",
+                    "include_hub_in_name": "Includere nume hub (controller) în numele entităților"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "temperature_entity": {
+                "name": "{entity_name} Temperatură"
+            },
+            "battery_entity": {
+                "name": "{entity_name} Baterie"
+            },
+            "humidity_entity": {
+                "name": "Umiditate"
+            },
+            "actuator_entity": {
+                "name": "Actuator {actuator_number}"
+            },
+            "window_sensor_entity": {
+                "name": "Fereastră {window_number}"
+            },
+            "ext_temperature_entity": {
+                "name": "Temperatură externă"
+            },
+            "signal_strength_entity": {
+                "name": "{entity_name} Putere semnal"
+            }
+        }
+    },
+    "title": "Controlere Tech"
+}

--- a/custom_components/tech/translations/ru.json
+++ b/custom_components/tech/translations/ru.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Устройство уже настроено",
+            "no_modules": "Не обнаружено модулей или выбрано"
+        },
+        "error": {
+            "cannot_connect": "Не удалось подключиться к Tech API.",
+            "invalid_auth": "Неверное имя пользователя или пароль!",
+            "unknown": "Неизвестная ошибка. Пожалуйста, попробуйте еще раз или сообщите об ошибке ..."
+        },
+        "step": {
+            "user": {
+                "title": "Вход в Tech Controllers",
+                "description": "Пожалуйста, введите ваши учетные данные для сервиса emodul.eu или emodul.pl.",
+                "data": {
+                    "password": "Пароль",
+                    "username": "Имя пользователя"
+                }
+            },
+            "select_controllers": {
+                "title": "Выбор контроллера",
+                "description": "Пожалуйста, выберите контроллеры, которые вы хотите интегрировать.",
+                "data": {
+                    "controllers": "Контроллеры для импорта",
+                    "include_hub_in_name": "Включить имя хаба (контроллера) в имена сущностей"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "temperature_entity": {
+                "name": "{entity_name} Температура"
+            },
+            "battery_entity": {
+                "name": "{entity_name} Заряд батареи"
+            },
+            "humidity_entity": {
+                "name": "Влажность"
+            },
+            "actuator_entity": {
+                "name": "Актуатор {actuator_number}"
+            },
+            "window_sensor_entity": {
+                "name": "Окно {window_number}"
+            },
+            "ext_temperature_entity": {
+                "name": "Внешняя температура"
+            },
+            "signal_strength_entity": {
+                "name": "{entity_name} Уровень сигнала"
+            }
+        }
+    },
+    "title": "Tech Controllers"
+}

--- a/custom_components/tech/translations/si.json
+++ b/custom_components/tech/translations/si.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Naprava je že konfigurirana",
+            "no_modules": "Ni zaznanih ali izbranih modulov"
+        },
+        "error": {
+            "cannot_connect": "Ne morem se povezati s Tech API.",
+            "invalid_auth": "Neveljavno uporabniško ime ali geslo!",
+            "unknown": "Neznana napaka. Prosimo, poskusite znova ali sporočite napako na ..."
+        },
+        "step": {
+            "user": {
+                "title": "Prijava v Tech Controllers",
+                "description": "Vnesite svoje poverilnice za storitev emodul.eu ali emodul.pl.",
+                "data": {
+                    "password": "Geslo",
+                    "username": "Uporabniško ime"
+                }
+            },
+            "select_controllers": {
+                "title": "Izbira krmilnikov",
+                "description": "Izberite krmilnike, ki jih želite integrirati.",
+                "data": {
+                    "controllers": "Krmilniki za uvoz",
+                    "include_hub_in_name": "Vključi ime glavnega krmilnika v imena entitet"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "temperature_entity": {
+                "name": "{entity_name} Temperatura"
+            },
+            "battery_entity": {
+                "name": "{entity_name} Baterija"
+            },
+            "humidity_entity": {
+                "name": "Vlažnost"
+            },
+            "actuator_entity": {
+                "name": "Aktuator {actuator_number}"
+            },
+            "window_sensor_entity": {
+                "name": "Okno {window_number}"
+            },
+            "ext_temperature_entity": {
+                "name": "Zunanja temperatura"
+            },
+            "signal_strength_entity": {
+                "name": "{entity_name} Moč signala"
+            }
+        }
+    },
+    "title": "Tech Controllers"
+}


### PR DESCRIPTION
I have generated language support for Integration in same languages which are available in [tech API](https://api-documentation.emodul.eu/)


Translations are generated using Github Copilot, I check few random translations and looks they are quite good and cover correctly field names.