### PR TITLE
✨ hide token even in debug mode

### DIFF
--- a/custom_components/tech/__init__.py
+++ b/custom_components/tech/__init__.py
@@ -35,6 +35,14 @@ async def async_setup(hass: HomeAssistant, config: dict):  # pylint: disable=unu
     return True
 
 
+def sanitize_entry_data(entry_data, key):
+    """Return a copy of entry_data with the specified key field hidden."""
+    sanitized_data = entry_data.copy()
+    if key in sanitized_data:
+        sanitized_data[key] = "***HIDDEN***"
+    return str(sanitized_data)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Tech Controllers from a config entry."""
     _LOGGER.debug("Setting up component's entry.")
@@ -42,7 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug(
         "Entry -> title: %s, data: %s, id: %s, domain: %s",
         entry.title,
-        str(entry.data),
+        sanitize_entry_data(entry.data, "token"),
         entry.entry_id,
         entry.domain,
     )


### PR DESCRIPTION
Even in debug mode we should not show a API token becuase this is very huge security risk. Some people which are not technical can be asked about logs from integration and they will not sanitize this info so after that they can have big issues caused by this approach.


This is sanitizing token in logs, people which will know what it is and for what is used will also know how to get it 