### PR TITLE
fix by adding async_migrate_entry

### DIFF
--- a/custom_components/tech/__init__.py
+++ b/custom_components/tech/__init__.py
@@ -118,3 +118,19 @@ class TechCoordinator(DataUpdateCoordinator):
             raise ConfigEntryAuthFailed from err
         except TechError as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Migrate old entry."""
+    _LOGGER.info("Migrating from version %s", config_entry.version)
+
+    if config_entry.version == 1:
+        _LOGGER.info("Migration not supported, please remove integration and add again to Home Assistant")
+        return False
+    elif config_entry.version == 2:
+        _LOGGER.info("Migration not supported, please remove integration and add again to Home Assistant")
+        return False
+    
+    # FIX ME: It require some handling in future
+    elif config_entry.version == 3:
+        _LOGGER.info("Migration non required")
+    return True


### PR DESCRIPTION
Close https://github.com/mariusz-ostoja-swierczynski/tech-controllers/issues/106


This is temporary fix as looks HA require to have `async_migrate_entry` when version of integration is updated (even when there is no update on `config_entry.version` or  `config_entry.minor_version`.

Adding for now it as workaround and later will work on some perm solution.