### PR TITLE
:sparkles: Add zone alarm state

### DIFF
--- a/custom_components/tech/const.py
+++ b/custom_components/tech/const.py
@@ -24,6 +24,7 @@ ACTUATORS_OPEN = "actuatorsOpen"
 INCLUDE_HUB_IN_NAME = "include_hub_in_name"
 WINDOW_SENSORS = "windowsSensors"
 WINDOW_STATE = "windowState"
+ZONE_STATE = "zoneState"
 
 DEFAULT_ICON = "mdi:eye"
 

--- a/custom_components/tech/strings.json
+++ b/custom_components/tech/strings.json
@@ -80,6 +80,9 @@
       },
       "signal_strength_entity": {
         "name": "{entity_name} signal strength"
+      },
+      "zone_state_entity": {
+        "name": "{entity_name} alarm state"
       }
     }
   }

--- a/custom_components/tech/translations/cs.json
+++ b/custom_components/tech/translations/cs.json
@@ -50,6 +50,9 @@
             },
             "signal_strength_entity": {
                 "name": "{entity_name} Síla signálu"
+            },
+            "zone_state_entity": {
+                "name": "{entity_name} Stav alarmu"
             }
         }
     },

--- a/custom_components/tech/translations/de.json
+++ b/custom_components/tech/translations/de.json
@@ -50,6 +50,9 @@
             },
             "signal_strength_entity": {
                 "name": "{entity_name} Signalstärke"
+            },
+            "zone_state_entity": {
+                "name": "{entity_name} Alarmzustand"
             }
         }
     },

--- a/custom_components/tech/translations/en.json
+++ b/custom_components/tech/translations/en.json
@@ -50,6 +50,9 @@
           },
           "signal_strength_entity": {
             "name": "{entity_name} Signal strength"
+          },
+          "zone_state_entity": {
+            "name": "{entity_name} Alarm state"
           }
         }
       },

--- a/custom_components/tech/translations/es.json
+++ b/custom_components/tech/translations/es.json
@@ -50,6 +50,9 @@
             },
             "signal_strength_entity": {
                 "name": "Intensidad de señal de {entity_name}"
+            },
+            "zone_state_entity": {
+                "name": "{entity_name} Estado de alarma"
             }
         }
     },

--- a/custom_components/tech/translations/et.json
+++ b/custom_components/tech/translations/et.json
@@ -50,6 +50,9 @@
             },
             "signal_strength_entity": {
                 "name": "{entity_name} Signaali tugevus"
+            },
+            "zone_state_entity": {
+                "name": "{entity_name} Häire olek"
             }
         }
     },

--- a/custom_components/tech/translations/fr.json
+++ b/custom_components/tech/translations/fr.json
@@ -50,6 +50,9 @@
             },
             "signal_strength_entity": {
                 "name": "Force du signal {entity_name}"
+            },
+            "zone_state_entity": {
+                "name": "{entity_name} État d'alarme"
             }
         }
     },

--- a/custom_components/tech/translations/hr.json
+++ b/custom_components/tech/translations/hr.json
@@ -50,6 +50,9 @@
             },
             "signal_strength_entity": {
                 "name": "{entity_name} Jačina signala"
+            },
+            "zone_state_entity": {
+                "name": "{entity_name} Alarmno stanje"
             }
         }
     },

--- a/custom_components/tech/translations/hu.json
+++ b/custom_components/tech/translations/hu.json
@@ -50,6 +50,9 @@
             },
             "signal_strength_entity": {
                 "name": "{entity_name} Jel erősség"
+            },
+            "zone_state_entity": {
+                "name": "{entity_name} Riasztási állapot"
             }
         }
     },

--- a/custom_components/tech/translations/it.json
+++ b/custom_components/tech/translations/it.json
@@ -50,6 +50,9 @@
             },
             "signal_strength_entity": {
                 "name": "{entity_name} Intensità del segnale"
+            },
+            "zone_state_entity": {
+                "name": "{entity_name} Stato di allarme"
             }
         }
     },

--- a/custom_components/tech/translations/lt.json
+++ b/custom_components/tech/translations/lt.json
@@ -50,6 +50,9 @@
             },
             "signal_strength_entity": {
                 "name": "{entity_name} Signalas"
+            },
+            "zone_state_entity": {
+                "name": "{entity_name} Signalizacijos būsena"
             }
         }
     },

--- a/custom_components/tech/translations/nl.json
+++ b/custom_components/tech/translations/nl.json
@@ -50,6 +50,9 @@
             },
             "signal_strength_entity": {
                 "name": "{entity_name} Signaalsterkte"
+            },
+            "zone_state_entity": {
+                "name": "{entity_name} Alarmstatus"
             }
         }
     },

--- a/custom_components/tech/translations/pl.json
+++ b/custom_components/tech/translations/pl.json
@@ -50,6 +50,9 @@
           },
           "signal_strength_entity": {
             "name": "{entity_name} Siła sygnału"
+          },
+          "zone_state_entity": {
+            "name": "{entity_name} Stan alarmu"
           }
         }
       },

--- a/custom_components/tech/translations/ro.json
+++ b/custom_components/tech/translations/ro.json
@@ -50,6 +50,9 @@
             },
             "signal_strength_entity": {
                 "name": "{entity_name} Putere semnal"
+            },
+            "zone_state_entity": {
+                "name": "{entity_name} Stare de alarmă"
             }
         }
     },

--- a/custom_components/tech/translations/ru.json
+++ b/custom_components/tech/translations/ru.json
@@ -50,6 +50,9 @@
             },
             "signal_strength_entity": {
                 "name": "{entity_name} Уровень сигнала"
+            },
+            "zone_state_entity": {
+                "name": "{entity_name} Состояние тревоги"
             }
         }
     },

--- a/custom_components/tech/translations/si.json
+++ b/custom_components/tech/translations/si.json
@@ -50,6 +50,9 @@
             },
             "signal_strength_entity": {
                 "name": "{entity_name} Moč signala"
+            },
+            "zone_state_entity": {
+                "name": "{entity_name} Stanje alarma"
             }
         }
     },

--- a/custom_components/tech/translations/sk.json
+++ b/custom_components/tech/translations/sk.json
@@ -50,6 +50,9 @@
           },
           "signal_strength_entity": {
             "name": "{entity_name} Intenzita signálu"
+          },
+          "zone_state_entity": {
+            "name": "{entity_name} Stav alarmu"
           }
         }
       },


### PR DESCRIPTION
Adds zone alarm status as binary sensor + attribute with detailed alarm state.

Implements #96 