### PR TITLE
Fix API tests compatibility with win32 platform.

### DIFF
--- a/tests/tests_api/__init__.py
+++ b/tests/tests_api/__init__.py
@@ -1,1 +1,7 @@
 """Tests for Tech API."""
+import sys
+import asyncio
+
+
+if sys.platform == 'win32':
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())


### PR DESCRIPTION
Hi,
I'm starting work to make this integration compatible with L-12 controllers and it is the first thing that I need to fix to start working :)
For more info please see https://github.com/aio-libs/aiodns/issues/86