### PR TITLE
Implement menu handling

### DIFF
--- a/custom_components/tech/assets.py
+++ b/custom_components/tech/assets.py
@@ -108,6 +108,97 @@ def build_menu_group_names(
     return groups
 
 
+def build_menu_zone_assignments(
+    menus: dict[str, dict[str, Any]],
+    zones: dict[int, dict[str, Any]],
+) -> dict[str, int]:
+    """Map menu item keys to zone IDs based on the menu tree hierarchy.
+
+    Finds the top-level "Zones" group whose direct group-children count matches
+    the number of zones, then walks the ``parentId`` tree to assign every
+    descendant item to the corresponding zone.
+
+    Args:
+        menus: Flat mapping of menu key to menu item payload.
+        zones: Mapping of zone ID to zone payload (as cached by the API client).
+
+    Returns:
+        Dictionary mapping menu item key (e.g. ``MI_308``) to zone ID.
+
+    """
+    if not zones:
+        return {}
+
+    # Index: (menuType, id) -> item for groups only
+    groups_by_key: dict[tuple[str, int], dict[str, Any]] = {}
+    # Index: (menuType, parentId) -> list of child group items
+    children_by_parent: dict[tuple[str, int], list[dict[str, Any]]] = {}
+
+    for item in menus.values():
+        if item.get("type") != MENU_ITEM_TYPE_GROUP:
+            continue
+        mt = item["menuType"]
+        groups_by_key[(mt, item["id"])] = item
+        children_by_parent.setdefault((mt, item.get("parentId", 0)), []).append(item)
+
+    # Find the "Zones" group: a top-level group (parentId=0) whose direct
+    # group-children count equals the number of zones.
+    zone_count = len(zones)
+    zones_group = None
+    for group in children_by_parent.get(("MI", 0), []) + children_by_parent.get(("MU", 0), []):
+        mt = group["menuType"]
+        direct_children = children_by_parent.get((mt, group["id"]), [])
+        if len(direct_children) == zone_count:
+            zones_group = group
+            break
+
+    if zones_group is None:
+        _LOGGER.debug("No 'Zones' menu group found matching %d zones", zone_count)
+        return {}
+
+    mt = zones_group["menuType"]
+    zone_subgroups = children_by_parent.get((mt, zones_group["id"]), [])
+    # Sort subgroups by id for stable positional matching
+    zone_subgroups.sort(key=lambda g: g["id"])
+
+    # Sort zones by index for positional matching
+    sorted_zone_ids = [
+        zid
+        for zid, zdata in sorted(zones.items(), key=lambda x: x[1]["zone"]["index"])
+    ]
+
+    if len(zone_subgroups) != len(sorted_zone_ids):
+        _LOGGER.debug("Zone subgroup count mismatch: %d groups vs %d zones",
+                       len(zone_subgroups), len(sorted_zone_ids))
+        return {}
+
+    # Map zone subgroup id -> zone_id
+    subgroup_to_zone: dict[int, int] = {
+        sg["id"]: zid for sg, zid in zip(zone_subgroups, sorted_zone_ids)
+    }
+
+    # Build full (menuType, parentId) -> [child keys] index for all items
+    all_children: dict[tuple[str, int], list[str]] = {}
+    for key, item in menus.items():
+        parent_key = (item["menuType"], item.get("parentId", 0))
+        all_children.setdefault(parent_key, []).append(key)
+
+    # BFS from each zone subgroup to collect all descendant menu keys
+    assignments: dict[str, int] = {}
+    for sg_id, zone_id in subgroup_to_zone.items():
+        queue = [sg_id]
+        while queue:
+            parent_id = queue.pop()
+            for child_key in all_children.get((mt, parent_id), []):
+                assignments[child_key] = zone_id
+                child_item = menus[child_key]
+                if child_item.get("type") == MENU_ITEM_TYPE_GROUP:
+                    queue.append(child_item["id"])
+
+    _LOGGER.debug("Assigned %d menu items to %d zones", len(assignments), len(subgroup_to_zone))
+    return assignments
+
+
 def menu_entity_name(
     item: dict[str, Any],
     group_names: dict[tuple[str, int], str],

--- a/custom_components/tech/assets.py
+++ b/custom_components/tech/assets.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 import logging
 from typing import Any
 
-from .const import DEFAULT_ICON, ICON_BY_ID, ICON_BY_TYPE, TXT_ID_BY_TYPE
+from .const import DEFAULT_ICON, ICON_BY_ID, ICON_BY_TYPE, MENU_ITEM_TYPE_GROUP, TXT_ID_BY_TYPE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,3 +82,56 @@ def get_icon(icon_id: int) -> str:
 def get_icon_by_type(icon_type: int) -> str:
     """Return the default icon assigned to the provided tile type."""
     return ICON_BY_TYPE.get(icon_type, DEFAULT_ICON)
+
+
+def build_menu_group_names(
+    menus: dict[str, dict[str, Any]],
+) -> dict[tuple[str, int], str]:
+    """Build a mapping of ``(menu_type, group_id)`` to translated group name.
+
+    Args:
+        menus: Flat mapping of menu key to menu item payload (as returned by
+            :meth:`Tech.get_module_menus`).
+
+    Returns:
+        Dictionary keyed by ``(menu_type, group_id)`` with the resolved group
+        label as value.
+
+    """
+    groups: dict[tuple[str, int], str] = {}
+    for item in menus.values():
+        if item.get("type") != MENU_ITEM_TYPE_GROUP:
+            continue
+        txt_id = item.get("txtId", 0)
+        name = get_text(txt_id) if txt_id else ""
+        groups[(item["menuType"], item["id"])] = name
+    return groups
+
+
+def menu_entity_name(
+    item: dict[str, Any],
+    group_names: dict[tuple[str, int], str],
+    prefix: str = "",
+) -> str:
+    """Return a human-readable entity name for a menu item.
+
+    When the item belongs to a non-root parent group the group label is
+    prepended so that ambiguous names like *On* gain context.
+
+    Args:
+        item: Menu item payload from the API.
+        group_names: Lookup returned by :func:`build_menu_group_names`.
+        prefix: Optional hub name prefix.
+
+    Returns:
+        Formatted entity name string.
+
+    """
+    txt_id = item.get("txtId", 0)
+    label = get_text(txt_id) if txt_id else f"Menu {item['id']}"
+    parent_id = item.get("parentId", 0)
+    if parent_id != 0:
+        parent_label = group_names.get((item["menuType"], parent_id), "")
+        if parent_label:
+            label = f"{parent_label} - {label}"
+    return prefix + label

--- a/custom_components/tech/button.py
+++ b/custom_components/tech/button.py
@@ -48,14 +48,19 @@ async def async_setup_entry(
     controller_udid = controller[UDID]
 
     menus = await coordinator.api.get_module_menus(controller_udid)
+    zones = await coordinator.api.get_module_zones(controller_udid)
     group_names = assets.build_menu_group_names(menus)
+    zone_assignments = assets.build_menu_zone_assignments(menus, zones)
 
     entities: list[MenuButtonEntity] = []
     for key, item in menus.items():
         if item.get("type") != MENU_ITEM_TYPE_DIALOGUE:
             continue
         entities.append(
-            MenuButtonEntity(item, key, coordinator, config_entry, group_names)
+            MenuButtonEntity(
+                item, key, coordinator, config_entry, group_names,
+                zone_id=zone_assignments.get(key),
+            )
         )
 
     async_add_entities(entities, True)
@@ -74,6 +79,7 @@ class MenuButtonEntity(CoordinatorEntity, ButtonEntity):
         coordinator: TechCoordinator,
         config_entry: ConfigEntry,
         group_names: dict[tuple[str, int], str],
+        zone_id: int | None = None,
     ) -> None:
         """Initialise a menu button entity.
 
@@ -83,6 +89,7 @@ class MenuButtonEntity(CoordinatorEntity, ButtonEntity):
             coordinator: Shared Tech data coordinator instance.
             config_entry: Config entry that owns the coordinator.
             group_names: Mapping of ``(menu_type, group_id)`` to group label.
+            zone_id: Optional zone ID to associate this entity with a zone device.
 
         """
         super().__init__(coordinator)
@@ -94,6 +101,7 @@ class MenuButtonEntity(CoordinatorEntity, ButtonEntity):
         self._menu_type = item["menuType"]
         self._unique_id = f"{self._udid}_menu_{menu_key}"
         self.manufacturer = MANUFACTURER
+        self._zone_id = zone_id
 
         prefix = (config_entry.title + " ") if config_entry.data[INCLUDE_HUB_IN_NAME] else ""
         self._name = assets.menu_entity_name(item, group_names, prefix)
@@ -119,11 +127,16 @@ class MenuButtonEntity(CoordinatorEntity, ButtonEntity):
 
     @property
     def device_info(self) -> DeviceInfo | None:
-        """Return Home Assistant ``DeviceInfo`` describing the controller."""
+        """Return device info for the zone or controller this entity belongs to."""
+        if self._zone_id is not None:
+            return {
+                ATTR_IDENTIFIERS: {(DOMAIN, f"{self._udid}_{self._zone_id}")},
+                ATTR_MANUFACTURER: self.manufacturer,
+            }
         return {
-            ATTR_IDENTIFIERS: {(DOMAIN, self._udid)},  # Unique identifiers for the device
-            CONF_NAME: self._config_entry.title,  # Name of the device
-            ATTR_MANUFACTURER: self.manufacturer,  # Manufacturer of the device
+            ATTR_IDENTIFIERS: {(DOMAIN, self._udid)},
+            CONF_NAME: self._config_entry.title,
+            ATTR_MANUFACTURER: self.manufacturer,
         }
 
     def _update_from_item(self, item: dict[str, Any]) -> None:

--- a/custom_components/tech/button.py
+++ b/custom_components/tech/button.py
@@ -1,0 +1,151 @@
+"""Platform for button entities backed by Tech menu dialogue parameters."""
+
+import logging
+from typing import Any
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    CONF_NAME,
+    EntityCategory,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import assets
+from .const import (
+    CONTROLLER,
+    DOMAIN,
+    INCLUDE_HUB_IN_NAME,
+    MANUFACTURER,
+    MENU_ITEM_TYPE_DIALOGUE,
+    UDID,
+)
+from .coordinator import TechCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Tech button entities from menu dialogue parameters.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: Integration entry containing controller data.
+        async_add_entities: Callback to register entities with Home Assistant.
+
+    """
+    controller = config_entry.data[CONTROLLER]
+    coordinator: TechCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    controller_udid = controller[UDID]
+
+    menus = await coordinator.api.get_module_menus(controller_udid)
+    group_names = assets.build_menu_group_names(menus)
+
+    entities: list[MenuButtonEntity] = []
+    for key, item in menus.items():
+        if item.get("type") != MENU_ITEM_TYPE_DIALOGUE:
+            continue
+        entities.append(
+            MenuButtonEntity(item, key, coordinator, config_entry, group_names)
+        )
+
+    async_add_entities(entities, True)
+
+
+class MenuButtonEntity(CoordinatorEntity, ButtonEntity):
+    """A dialogue menu parameter exposed as a Home Assistant button entity."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        item: dict[str, Any],
+        menu_key: str,
+        coordinator: TechCoordinator,
+        config_entry: ConfigEntry,
+        group_names: dict[tuple[str, int], str],
+    ) -> None:
+        """Initialise a menu button entity.
+
+        Args:
+            item: Menu item payload returned by the Tech API.
+            menu_key: Unique key identifying this menu item (e.g. ``MU_250``).
+            coordinator: Shared Tech data coordinator instance.
+            config_entry: Config entry that owns the coordinator.
+            group_names: Mapping of ``(menu_type, group_id)`` to group label.
+
+        """
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._coordinator = coordinator
+        self._udid = config_entry.data[CONTROLLER][UDID]
+        self._menu_key = menu_key
+        self._item_id = item["id"]
+        self._menu_type = item["menuType"]
+        self._unique_id = f"{self._udid}_menu_{menu_key}"
+        self.manufacturer = MANUFACTURER
+
+        prefix = (config_entry.title + " ") if config_entry.data[INCLUDE_HUB_IN_NAME] else ""
+        self._name = assets.menu_entity_name(item, group_names, prefix)
+
+        self._update_from_item(item)
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._unique_id
+
+    @property
+    def name(self) -> str:
+        """Return the display name of this entity."""
+        return self._name
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return Home Assistant ``DeviceInfo`` describing the controller."""
+        return {
+            ATTR_IDENTIFIERS: {(DOMAIN, self._udid)},  # Unique identifiers for the device
+            CONF_NAME: self._config_entry.title,  # Name of the device
+            ATTR_MANUFACTURER: self.manufacturer,  # Manufacturer of the device
+        }
+
+    def _update_from_item(self, item: dict[str, Any]) -> None:
+        """Refresh entity properties from the menu item payload.
+
+        Args:
+            item: Menu item dictionary with the most recent values.
+
+        """
+        self._attr_available = item.get("access", False)
+        # Dialogue type determines the API payload format
+        params = item.get("params", {})
+        self._dialogue_type = params.get("type", 0)
+
+    async def async_press(self) -> None:
+        """Handle the button press by triggering the dialogue action."""
+        await self.coordinator.api.set_menu_value(
+            self._udid,
+            self._menu_type,
+            self._item_id,
+            {"type": self._dialogue_type, "value": 1},
+        )
+        await self.coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self, *args: Any) -> None:
+        """Handle updated data from the coordinator."""
+        menus = self._coordinator.data.get("menus", {})
+        item = menus.get(self._menu_key)
+        if item:
+            self._update_from_item(item)
+        self.async_write_ha_state()

--- a/custom_components/tech/button.py
+++ b/custom_components/tech/button.py
@@ -98,6 +98,8 @@ class MenuButtonEntity(CoordinatorEntity, ButtonEntity):
         prefix = (config_entry.title + " ") if config_entry.data[INCLUDE_HUB_IN_NAME] else ""
         self._name = assets.menu_entity_name(item, group_names, prefix)
 
+        self._disabled = item.get("parentId", 0) != 0
+
         self._update_from_item(item)
 
     @property
@@ -109,6 +111,11 @@ class MenuButtonEntity(CoordinatorEntity, ButtonEntity):
     def name(self) -> str:
         """Return the display name of this entity."""
         return self._name
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return whether the entity should be enabled by default."""
+        return not self._disabled
 
     @property
     def device_info(self) -> DeviceInfo | None:

--- a/custom_components/tech/const.py
+++ b/custom_components/tech/const.py
@@ -41,7 +41,15 @@ ZONE_STATE = "zoneState"
 
 DEFAULT_ICON = "mdi:eye"
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.CLIMATE, Platform.SENSOR]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.CLIMATE,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 SCAN_INTERVAL: Final = timedelta(seconds=60)
 API_TIMEOUT: Final = 60
@@ -98,6 +106,30 @@ OPENTHERM_CURRENT_TEMP = {"txt_id": 127, "state_key": "currentTemp"}
 OPENTHERM_CURRENT_TEMP_DHW = {"txt_id": 128, "state_key": "currentTempDHW"}
 OPENTHERM_SET_TEMP = {"txt_id": 1058, "state_key": "setCurrentTemp"}
 OPENTHERM_SET_TEMP_DHW = {"txt_id": 1059, "state_key": "setTempDHW"}
+
+# Menu types
+MENU_TYPE_USER = "MU"
+MENU_TYPE_INSTALLER = "MI"
+MENU_TYPE_SERVICE = "MS"
+MENU_TYPE_MANUFACTURER = "MP"
+MENU_TYPES = [MENU_TYPE_USER, MENU_TYPE_INSTALLER]
+
+# Menu item types
+MENU_ITEM_TYPE_GROUP = 0
+MENU_ITEM_TYPE_VALUE = {1, 2, 3, 4, 5}
+MENU_ITEM_TYPE_CODE = 6
+MENU_ITEM_TYPE_TIME_MODE = 7
+MENU_ITEM_TYPE_ON_OFF = 10
+MENU_ITEM_TYPE_CHOICE = {11, 111, 112}
+MENU_ITEM_TYPE_DIALOGUE = 20
+MENU_ITEM_TYPE_UNIVERSAL_VALUE = 106
+
+# Value format types for menu items
+VALUE_FORMAT_NORMAL = 1
+VALUE_FORMAT_TENTH = 2
+VALUE_FORMAT_MIN_SEC = 3
+VALUE_FORMAT_HOUR_MIN = 4
+VALUE_FORMAT_H_MIN_DAY = 5
 
 TECH_SUPPORTED_LANGUAGES = [
     "en",

--- a/custom_components/tech/number.py
+++ b/custom_components/tech/number.py
@@ -52,7 +52,9 @@ async def async_setup_entry(
     controller_udid = controller[UDID]
 
     menus = await coordinator.api.get_module_menus(controller_udid)
+    zones = await coordinator.api.get_module_zones(controller_udid)
     group_names = assets.build_menu_group_names(menus)
+    zone_assignments = assets.build_menu_zone_assignments(menus, zones)
 
     entities: list[MenuNumberEntity] = []
     for key, item in menus.items():
@@ -62,7 +64,10 @@ async def async_setup_entry(
         if not item.get("access", False):
             continue
         entities.append(
-            MenuNumberEntity(item, key, coordinator, config_entry, group_names)
+            MenuNumberEntity(
+                item, key, coordinator, config_entry, group_names,
+                zone_id=zone_assignments.get(key),
+            )
         )
 
     async_add_entities(entities, True)
@@ -81,6 +86,7 @@ class MenuNumberEntity(CoordinatorEntity, NumberEntity):
         coordinator: TechCoordinator,
         config_entry: ConfigEntry,
         group_names: dict[tuple[str, int], str],
+        zone_id: int | None = None,
     ) -> None:
         """Initialise a menu number entity.
 
@@ -90,6 +96,7 @@ class MenuNumberEntity(CoordinatorEntity, NumberEntity):
             coordinator: Shared Tech data coordinator instance.
             config_entry: Config entry that owns the coordinator.
             group_names: Mapping of ``(menu_type, group_id)`` to group label.
+            zone_id: Optional zone ID to associate this entity with a zone device.
 
         """
         super().__init__(coordinator)
@@ -101,6 +108,7 @@ class MenuNumberEntity(CoordinatorEntity, NumberEntity):
         self._menu_type = item["menuType"]
         self._unique_id = f"{self._udid}_menu_{menu_key}"
         self.manufacturer = MANUFACTURER
+        self._zone_id = zone_id
 
         params = item.get("params", {})
         self._format = params.get("format", 1)
@@ -131,11 +139,16 @@ class MenuNumberEntity(CoordinatorEntity, NumberEntity):
 
     @property
     def device_info(self) -> DeviceInfo | None:
-        """Return Home Assistant ``DeviceInfo`` describing the controller."""
+        """Return device info for the zone or controller this entity belongs to."""
+        if self._zone_id is not None:
+            return {
+                ATTR_IDENTIFIERS: {(DOMAIN, f"{self._udid}_{self._zone_id}")},
+                ATTR_MANUFACTURER: self.manufacturer,
+            }
         return {
-            ATTR_IDENTIFIERS: {(DOMAIN, self._udid)},  # Unique identifiers for the device
-            CONF_NAME: self._config_entry.title,  # Name of the device
-            ATTR_MANUFACTURER: self.manufacturer,  # Manufacturer of the device
+            ATTR_IDENTIFIERS: {(DOMAIN, self._udid)},
+            CONF_NAME: self._config_entry.title,
+            ATTR_MANUFACTURER: self.manufacturer,
         }
 
     def _update_from_item(self, item: dict[str, Any]) -> None:

--- a/custom_components/tech/number.py
+++ b/custom_components/tech/number.py
@@ -110,6 +110,8 @@ class MenuNumberEntity(CoordinatorEntity, NumberEntity):
         prefix = (config_entry.title + " ") if config_entry.data[INCLUDE_HUB_IN_NAME] else ""
         self._name = assets.menu_entity_name(item, group_names, prefix)
 
+        self._disabled = item.get("parentId", 0) != 0
+
         self._update_from_item(item)
 
     @property
@@ -121,6 +123,11 @@ class MenuNumberEntity(CoordinatorEntity, NumberEntity):
     def name(self) -> str:
         """Return the display name of this entity."""
         return self._name
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return whether the entity should be enabled by default."""
+        return not self._disabled
 
     @property
     def device_info(self) -> DeviceInfo | None:

--- a/custom_components/tech/number.py
+++ b/custom_components/tech/number.py
@@ -1,0 +1,178 @@
+"""Platform for number entities backed by Tech menu parameters."""
+
+import logging
+from typing import Any
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    CONF_NAME,
+    EntityCategory,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import assets
+from .const import (
+    CONTROLLER,
+    DOMAIN,
+    INCLUDE_HUB_IN_NAME,
+    MANUFACTURER,
+    MENU_ITEM_TYPE_UNIVERSAL_VALUE,
+    MENU_ITEM_TYPE_VALUE,
+    UDID,
+    VALUE_FORMAT_TENTH,
+)
+from .coordinator import TechCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+_EDITABLE_TYPES = MENU_ITEM_TYPE_VALUE | {MENU_ITEM_TYPE_UNIVERSAL_VALUE}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Tech number entities from menu parameters.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: Integration entry containing controller data.
+        async_add_entities: Callback to register entities with Home Assistant.
+
+    """
+    controller = config_entry.data[CONTROLLER]
+    coordinator: TechCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    controller_udid = controller[UDID]
+
+    menus = await coordinator.api.get_module_menus(controller_udid)
+    group_names = assets.build_menu_group_names(menus)
+
+    entities: list[MenuNumberEntity] = []
+    for key, item in menus.items():
+        item_type = item.get("type")
+        if item_type not in _EDITABLE_TYPES:
+            continue
+        if not item.get("access", False):
+            continue
+        entities.append(
+            MenuNumberEntity(item, key, coordinator, config_entry, group_names)
+        )
+
+    async_add_entities(entities, True)
+
+
+class MenuNumberEntity(CoordinatorEntity, NumberEntity):
+    """A numeric menu parameter exposed as a Home Assistant number entity."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        item: dict[str, Any],
+        menu_key: str,
+        coordinator: TechCoordinator,
+        config_entry: ConfigEntry,
+        group_names: dict[tuple[str, int], str],
+    ) -> None:
+        """Initialise a menu number entity.
+
+        Args:
+            item: Menu item payload returned by the Tech API.
+            menu_key: Unique key identifying this menu item (e.g. ``MU_2089``).
+            coordinator: Shared Tech data coordinator instance.
+            config_entry: Config entry that owns the coordinator.
+            group_names: Mapping of ``(menu_type, group_id)`` to group label.
+
+        """
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._coordinator = coordinator
+        self._udid = config_entry.data[CONTROLLER][UDID]
+        self._menu_key = menu_key
+        self._item_id = item["id"]
+        self._menu_type = item["menuType"]
+        self._unique_id = f"{self._udid}_menu_{menu_key}"
+        self.manufacturer = MANUFACTURER
+
+        params = item.get("params", {})
+        self._format = params.get("format", 1)
+
+        self._attr_mode = NumberMode.BOX
+
+        prefix = (config_entry.title + " ") if config_entry.data[INCLUDE_HUB_IN_NAME] else ""
+        self._name = assets.menu_entity_name(item, group_names, prefix)
+
+        self._update_from_item(item)
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._unique_id
+
+    @property
+    def name(self) -> str:
+        """Return the display name of this entity."""
+        return self._name
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return Home Assistant ``DeviceInfo`` describing the controller."""
+        return {
+            ATTR_IDENTIFIERS: {(DOMAIN, self._udid)},  # Unique identifiers for the device
+            CONF_NAME: self._config_entry.title,  # Name of the device
+            ATTR_MANUFACTURER: self.manufacturer,  # Manufacturer of the device
+        }
+
+    def _update_from_item(self, item: dict[str, Any]) -> None:
+        """Refresh entity properties from a menu item payload.
+
+        Args:
+            item: Menu item dictionary with the most recent values.
+
+        """
+        params = item.get("params", {})
+        self._format = params.get("format", 1)
+        raw_value = params.get("value", 0)
+        raw_min = params.get("min", 0)
+        raw_max = params.get("max", 100)
+        step = params.get("jump", 1)
+
+        if self._format == VALUE_FORMAT_TENTH:
+            self._attr_native_value = raw_value / 10.0
+            self._attr_native_min_value = raw_min / 10.0
+            self._attr_native_max_value = raw_max / 10.0
+            self._attr_native_step = step / 10.0
+        else:
+            self._attr_native_value = float(raw_value)
+            self._attr_native_min_value = float(raw_min)
+            self._attr_native_max_value = float(raw_max)
+            self._attr_native_step = float(step)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the menu parameter to the requested value."""
+        if self._format == VALUE_FORMAT_TENTH:
+            api_value = int(value * 10)
+        else:
+            api_value = int(value)
+
+        await self.coordinator.api.set_menu_value(
+            self._udid, self._menu_type, self._item_id, {"value": api_value}
+        )
+        await self.coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self, *args: Any) -> None:
+        """Handle updated data from the coordinator."""
+        menus = self._coordinator.data.get("menus", {})
+        item = menus.get(self._menu_key)
+        if item:
+            self._update_from_item(item)
+        self.async_write_ha_state()

--- a/custom_components/tech/select.py
+++ b/custom_components/tech/select.py
@@ -1,0 +1,195 @@
+"""Platform for select entities backed by Tech menu choice parameters."""
+
+import logging
+from typing import Any
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    CONF_NAME,
+    EntityCategory,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import assets
+from .const import (
+    CONTROLLER,
+    DOMAIN,
+    INCLUDE_HUB_IN_NAME,
+    MANUFACTURER,
+    MENU_ITEM_TYPE_CHOICE,
+    UDID,
+)
+from .coordinator import TechCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Tech select entities from menu choice parameters.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: Integration entry containing controller data.
+        async_add_entities: Callback to register entities with Home Assistant.
+
+    """
+    controller = config_entry.data[CONTROLLER]
+    coordinator: TechCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    controller_udid = controller[UDID]
+
+    menus = await coordinator.api.get_module_menus(controller_udid)
+    group_names = assets.build_menu_group_names(menus)
+
+    entities: list[MenuSelectEntity] = []
+    for key, item in menus.items():
+        if item.get("type") not in MENU_ITEM_TYPE_CHOICE:
+            continue
+        if not item.get("access", False):
+            continue
+        options = item.get("params", {}).get("options", [])
+        if not options:
+            continue
+        entities.append(
+            MenuSelectEntity(item, key, coordinator, config_entry, group_names)
+        )
+
+    async_add_entities(entities, True)
+
+
+class MenuSelectEntity(CoordinatorEntity, SelectEntity):
+    """A choice menu parameter exposed as a Home Assistant select entity."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        item: dict[str, Any],
+        menu_key: str,
+        coordinator: TechCoordinator,
+        config_entry: ConfigEntry,
+        group_names: dict[tuple[str, int], str],
+    ) -> None:
+        """Initialise a menu select entity.
+
+        Args:
+            item: Menu item payload returned by the Tech API.
+            menu_key: Unique key identifying this menu item (e.g. ``MU_2011``).
+            coordinator: Shared Tech data coordinator instance.
+            config_entry: Config entry that owns the coordinator.
+            group_names: Mapping of ``(menu_type, group_id)`` to group label.
+
+        """
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._coordinator = coordinator
+        self._udid = config_entry.data[CONTROLLER][UDID]
+        self._menu_key = menu_key
+        self._item_id = item["id"]
+        self._menu_type = item["menuType"]
+        self._unique_id = f"{self._udid}_menu_{menu_key}"
+        self.manufacturer = MANUFACTURER
+
+        prefix = (config_entry.title + " ") if config_entry.data[INCLUDE_HUB_IN_NAME] else ""
+        self._name = assets.menu_entity_name(item, group_names, prefix)
+
+        self._value_to_label: dict[int, str] = {}
+        self._label_to_value: dict[str, int] = {}
+        self._update_from_item(item)
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._unique_id
+
+    @property
+    def name(self) -> str:
+        """Return the display name of this entity."""
+        return self._name
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return Home Assistant ``DeviceInfo`` describing the controller."""
+        return {
+            ATTR_IDENTIFIERS: {(DOMAIN, self._udid)},  # Unique identifiers for the device
+            CONF_NAME: self._config_entry.title,  # Name of the device
+            ATTR_MANUFACTURER: self.manufacturer,  # Manufacturer of the device
+        }
+
+    def _build_option_maps(self, options: list[dict[str, Any]]) -> None:
+        """Build label/value mappings from the API options list.
+
+        Args:
+            options: List of option dictionaries containing ``value`` and ``txtId``.
+
+        """
+        self._value_to_label = {}
+        self._label_to_value = {}
+        ha_options: list[str] = []
+
+        for opt in options:
+            if isinstance(opt, dict):
+                val = opt.get("value", 0)
+                txt_id = opt.get("txtId", 0)
+            else:
+                continue
+            label = assets.get_text(txt_id) if txt_id else str(val)
+            # Ensure unique labels
+            if label in self._label_to_value:
+                label = f"{label} ({val})"
+            self._value_to_label[val] = label
+            self._label_to_value[label] = val
+            ha_options.append(label)
+
+        self._attr_options = ha_options
+
+    def _update_from_item(self, item: dict[str, Any]) -> None:
+        """Refresh entity properties from a menu item payload.
+
+        Args:
+            item: Menu item dictionary with the most recent values.
+
+        """
+        params = item.get("params", {})
+        options = params.get("options", [])
+        self._build_option_maps(options)
+
+        current_value = params.get("value", 0)
+        current_label = self._value_to_label.get(current_value)
+        if current_label and current_label in self._attr_options:
+            self._attr_current_option = current_label
+        elif self._attr_options:
+            self._attr_current_option = self._attr_options[0]
+        else:
+            self._attr_current_option = None
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        value = self._label_to_value.get(option)
+        if value is None:
+            _LOGGER.warning("Unknown option %s for menu item %s", option, self._item_id)
+            return
+
+        await self.coordinator.api.set_menu_value(
+            self._udid, self._menu_type, self._item_id, {"value": value}
+        )
+        await self.coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self, *args: Any) -> None:
+        """Handle updated data from the coordinator."""
+        menus = self._coordinator.data.get("menus", {})
+        item = menus.get(self._menu_key)
+        if item:
+            self._update_from_item(item)
+        self.async_write_ha_state()

--- a/custom_components/tech/select.py
+++ b/custom_components/tech/select.py
@@ -103,6 +103,8 @@ class MenuSelectEntity(CoordinatorEntity, SelectEntity):
         prefix = (config_entry.title + " ") if config_entry.data[INCLUDE_HUB_IN_NAME] else ""
         self._name = assets.menu_entity_name(item, group_names, prefix)
 
+        self._disabled = item.get("parentId", 0) != 0
+
         self._value_to_label: dict[int, str] = {}
         self._label_to_value: dict[str, int] = {}
         self._update_from_item(item)
@@ -116,6 +118,11 @@ class MenuSelectEntity(CoordinatorEntity, SelectEntity):
     def name(self) -> str:
         """Return the display name of this entity."""
         return self._name
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return whether the entity should be enabled by default."""
+        return not self._disabled
 
     @property
     def device_info(self) -> DeviceInfo | None:

--- a/custom_components/tech/select.py
+++ b/custom_components/tech/select.py
@@ -48,7 +48,9 @@ async def async_setup_entry(
     controller_udid = controller[UDID]
 
     menus = await coordinator.api.get_module_menus(controller_udid)
+    zones = await coordinator.api.get_module_zones(controller_udid)
     group_names = assets.build_menu_group_names(menus)
+    zone_assignments = assets.build_menu_zone_assignments(menus, zones)
 
     entities: list[MenuSelectEntity] = []
     for key, item in menus.items():
@@ -60,7 +62,10 @@ async def async_setup_entry(
         if not options:
             continue
         entities.append(
-            MenuSelectEntity(item, key, coordinator, config_entry, group_names)
+            MenuSelectEntity(
+                item, key, coordinator, config_entry, group_names,
+                zone_id=zone_assignments.get(key),
+            )
         )
 
     async_add_entities(entities, True)
@@ -79,6 +84,7 @@ class MenuSelectEntity(CoordinatorEntity, SelectEntity):
         coordinator: TechCoordinator,
         config_entry: ConfigEntry,
         group_names: dict[tuple[str, int], str],
+        zone_id: int | None = None,
     ) -> None:
         """Initialise a menu select entity.
 
@@ -88,6 +94,7 @@ class MenuSelectEntity(CoordinatorEntity, SelectEntity):
             coordinator: Shared Tech data coordinator instance.
             config_entry: Config entry that owns the coordinator.
             group_names: Mapping of ``(menu_type, group_id)`` to group label.
+            zone_id: Optional zone ID to associate this entity with a zone device.
 
         """
         super().__init__(coordinator)
@@ -99,6 +106,7 @@ class MenuSelectEntity(CoordinatorEntity, SelectEntity):
         self._menu_type = item["menuType"]
         self._unique_id = f"{self._udid}_menu_{menu_key}"
         self.manufacturer = MANUFACTURER
+        self._zone_id = zone_id
 
         prefix = (config_entry.title + " ") if config_entry.data[INCLUDE_HUB_IN_NAME] else ""
         self._name = assets.menu_entity_name(item, group_names, prefix)
@@ -126,11 +134,16 @@ class MenuSelectEntity(CoordinatorEntity, SelectEntity):
 
     @property
     def device_info(self) -> DeviceInfo | None:
-        """Return Home Assistant ``DeviceInfo`` describing the controller."""
+        """Return device info for the zone or controller this entity belongs to."""
+        if self._zone_id is not None:
+            return {
+                ATTR_IDENTIFIERS: {(DOMAIN, f"{self._udid}_{self._zone_id}")},
+                ATTR_MANUFACTURER: self.manufacturer,
+            }
         return {
-            ATTR_IDENTIFIERS: {(DOMAIN, self._udid)},  # Unique identifiers for the device
-            CONF_NAME: self._config_entry.title,  # Name of the device
-            ATTR_MANUFACTURER: self.manufacturer,  # Manufacturer of the device
+            ATTR_IDENTIFIERS: {(DOMAIN, self._udid)},
+            CONF_NAME: self._config_entry.title,
+            ATTR_MANUFACTURER: self.manufacturer,
         }
 
     def _build_option_maps(self, options: list[dict[str, Any]]) -> None:

--- a/custom_components/tech/switch.py
+++ b/custom_components/tech/switch.py
@@ -100,6 +100,8 @@ class MenuSwitchEntity(CoordinatorEntity, SwitchEntity):
         prefix = (config_entry.title + " ") if config_entry.data[INCLUDE_HUB_IN_NAME] else ""
         self._name = assets.menu_entity_name(item, group_names, prefix)
 
+        self._disabled = item.get("parentId", 0) != 0
+
         self._update_from_item(item)
 
     @property
@@ -111,6 +113,11 @@ class MenuSwitchEntity(CoordinatorEntity, SwitchEntity):
     def name(self) -> str:
         """Return the display name of this entity."""
         return self._name
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return whether the entity should be enabled by default."""
+        return not self._disabled
 
     @property
     def device_info(self) -> DeviceInfo | None:

--- a/custom_components/tech/switch.py
+++ b/custom_components/tech/switch.py
@@ -48,7 +48,9 @@ async def async_setup_entry(
     controller_udid = controller[UDID]
 
     menus = await coordinator.api.get_module_menus(controller_udid)
+    zones = await coordinator.api.get_module_zones(controller_udid)
     group_names = assets.build_menu_group_names(menus)
+    zone_assignments = assets.build_menu_zone_assignments(menus, zones)
 
     entities: list[MenuSwitchEntity] = []
     for key, item in menus.items():
@@ -57,7 +59,10 @@ async def async_setup_entry(
         if not item.get("access", False):
             continue
         entities.append(
-            MenuSwitchEntity(item, key, coordinator, config_entry, group_names)
+            MenuSwitchEntity(
+                item, key, coordinator, config_entry, group_names,
+                zone_id=zone_assignments.get(key),
+            )
         )
 
     async_add_entities(entities, True)
@@ -76,6 +81,7 @@ class MenuSwitchEntity(CoordinatorEntity, SwitchEntity):
         coordinator: TechCoordinator,
         config_entry: ConfigEntry,
         group_names: dict[tuple[str, int], str],
+        zone_id: int | None = None,
     ) -> None:
         """Initialise a menu switch entity.
 
@@ -85,6 +91,7 @@ class MenuSwitchEntity(CoordinatorEntity, SwitchEntity):
             coordinator: Shared Tech data coordinator instance.
             config_entry: Config entry that owns the coordinator.
             group_names: Mapping of ``(menu_type, group_id)`` to group label.
+            zone_id: Optional zone ID to associate this entity with a zone device.
 
         """
         super().__init__(coordinator)
@@ -96,6 +103,7 @@ class MenuSwitchEntity(CoordinatorEntity, SwitchEntity):
         self._menu_type = item["menuType"]
         self._unique_id = f"{self._udid}_menu_{menu_key}"
         self.manufacturer = MANUFACTURER
+        self._zone_id = zone_id
 
         prefix = (config_entry.title + " ") if config_entry.data[INCLUDE_HUB_IN_NAME] else ""
         self._name = assets.menu_entity_name(item, group_names, prefix)
@@ -121,11 +129,16 @@ class MenuSwitchEntity(CoordinatorEntity, SwitchEntity):
 
     @property
     def device_info(self) -> DeviceInfo | None:
-        """Return Home Assistant ``DeviceInfo`` describing the controller."""
+        """Return device info for the zone or controller this entity belongs to."""
+        if self._zone_id is not None:
+            return {
+                ATTR_IDENTIFIERS: {(DOMAIN, f"{self._udid}_{self._zone_id}")},
+                ATTR_MANUFACTURER: self.manufacturer,
+            }
         return {
-            ATTR_IDENTIFIERS: {(DOMAIN, self._udid)},  # Unique identifiers for the device
-            CONF_NAME: self._config_entry.title,  # Name of the device
-            ATTR_MANUFACTURER: self.manufacturer,  # Manufacturer of the device
+            ATTR_IDENTIFIERS: {(DOMAIN, self._udid)},
+            CONF_NAME: self._config_entry.title,
+            ATTR_MANUFACTURER: self.manufacturer,
         }
 
     def _update_from_item(self, item: dict[str, Any]) -> None:

--- a/custom_components/tech/switch.py
+++ b/custom_components/tech/switch.py
@@ -1,0 +1,155 @@
+"""Platform for switch entities backed by Tech menu on/off parameters."""
+
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    CONF_NAME,
+    EntityCategory,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import assets
+from .const import (
+    CONTROLLER,
+    DOMAIN,
+    INCLUDE_HUB_IN_NAME,
+    MANUFACTURER,
+    MENU_ITEM_TYPE_ON_OFF,
+    UDID,
+)
+from .coordinator import TechCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Tech switch entities from menu on/off parameters.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: Integration entry containing controller data.
+        async_add_entities: Callback to register entities with Home Assistant.
+
+    """
+    controller = config_entry.data[CONTROLLER]
+    coordinator: TechCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    controller_udid = controller[UDID]
+
+    menus = await coordinator.api.get_module_menus(controller_udid)
+    group_names = assets.build_menu_group_names(menus)
+
+    entities: list[MenuSwitchEntity] = []
+    for key, item in menus.items():
+        if item.get("type") != MENU_ITEM_TYPE_ON_OFF:
+            continue
+        if not item.get("access", False):
+            continue
+        entities.append(
+            MenuSwitchEntity(item, key, coordinator, config_entry, group_names)
+        )
+
+    async_add_entities(entities, True)
+
+
+class MenuSwitchEntity(CoordinatorEntity, SwitchEntity):
+    """An on/off menu parameter exposed as a Home Assistant switch entity."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        item: dict[str, Any],
+        menu_key: str,
+        coordinator: TechCoordinator,
+        config_entry: ConfigEntry,
+        group_names: dict[tuple[str, int], str],
+    ) -> None:
+        """Initialise a menu switch entity.
+
+        Args:
+            item: Menu item payload returned by the Tech API.
+            menu_key: Unique key identifying this menu item (e.g. ``MU_3550``).
+            coordinator: Shared Tech data coordinator instance.
+            config_entry: Config entry that owns the coordinator.
+            group_names: Mapping of ``(menu_type, group_id)`` to group label.
+
+        """
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._coordinator = coordinator
+        self._udid = config_entry.data[CONTROLLER][UDID]
+        self._menu_key = menu_key
+        self._item_id = item["id"]
+        self._menu_type = item["menuType"]
+        self._unique_id = f"{self._udid}_menu_{menu_key}"
+        self.manufacturer = MANUFACTURER
+
+        prefix = (config_entry.title + " ") if config_entry.data[INCLUDE_HUB_IN_NAME] else ""
+        self._name = assets.menu_entity_name(item, group_names, prefix)
+
+        self._update_from_item(item)
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._unique_id
+
+    @property
+    def name(self) -> str:
+        """Return the display name of this entity."""
+        return self._name
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return Home Assistant ``DeviceInfo`` describing the controller."""
+        return {
+            ATTR_IDENTIFIERS: {(DOMAIN, self._udid)},  # Unique identifiers for the device
+            CONF_NAME: self._config_entry.title,  # Name of the device
+            ATTR_MANUFACTURER: self.manufacturer,  # Manufacturer of the device
+        }
+
+    def _update_from_item(self, item: dict[str, Any]) -> None:
+        """Refresh entity properties from a menu item payload.
+
+        Args:
+            item: Menu item dictionary with the most recent values.
+
+        """
+        params = item.get("params", {})
+        self._attr_is_on = params.get("value", 0) == 1
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        await self.coordinator.api.set_menu_value(
+            self._udid, self._menu_type, self._item_id, {"value": 1}
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        await self.coordinator.api.set_menu_value(
+            self._udid, self._menu_type, self._item_id, {"value": 0}
+        )
+        await self.coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self, *args: Any) -> None:
+        """Handle updated data from the coordinator."""
+        menus = self._coordinator.data.get("menus", {})
+        item = menus.get(self._menu_key)
+        if item:
+            self._update_from_item(item)
+        self.async_write_ha_state()

--- a/custom_components/tech/tech.py
+++ b/custom_components/tech/tech.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
 else:  # pragma: no cover
     ClientSession = Any
 
-from .const import TECH_SUPPORTED_LANGUAGES
+from .const import MENU_TYPES, TECH_SUPPORTED_LANGUAGES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -244,7 +244,7 @@ class Tech:
         now = time.time()
 
         cache = self.modules.setdefault(
-            module_udid, {"last_update": None, "zones": {}, "tiles": {}}
+            module_udid, {"last_update": None, "zones": {}, "tiles": {}, "menus": {}}
         )
 
         _LOGGER.debug("Updating module zones & tiles ... %s", module_udid)
@@ -275,8 +275,94 @@ class Tech:
             )
             cache["tiles"].update({tile["id"]: tile for tile in visible_tiles})
 
+        menu_items = await self._fetch_menu_data(module_udid)
+        if menu_items:
+            _LOGGER.debug(
+                "Updating %s menu items for controller: %s",
+                len(menu_items),
+                module_udid,
+            )
+            cache.setdefault("menus", {}).update(menu_items)
+
         cache["last_update"] = now
         return cache
+
+    async def _fetch_menu_data(
+        self, module_udid: str
+    ) -> dict[str, dict[str, Any]]:
+        """Fetch menu items from all configured menu types.
+
+        Args:
+            module_udid: Tech module identifier.
+
+        Returns:
+            Mapping of ``{menu_type}_{item_id}`` to menu item payload.
+
+        """
+        items: dict[str, dict[str, Any]] = {}
+        for menu_type in MENU_TYPES:
+            try:
+                path = f"users/{self.user_id}/modules/{module_udid}/menu/{menu_type}/"
+                result = await self.get(path)
+                elements = result.get("data", {}).get("elements", [])
+                for element in elements:
+                    item_id = element.get("id")
+                    if item_id is not None:
+                        key = f"{menu_type}_{item_id}"
+                        items[key] = element
+            except TechError:
+                _LOGGER.debug(
+                    "Menu type %s not available for module %s",
+                    menu_type,
+                    module_udid,
+                )
+        return items
+
+    async def get_module_menus(
+        self, module_udid: str
+    ) -> dict[str, dict[str, Any]]:
+        """Return the cached menu items dictionary for ``module_udid``.
+
+        Args:
+            module_udid: Tech module identifier.
+
+        Returns:
+            Mapping of menu item key to menu item payload.
+
+        """
+        module = await self.module_data(module_udid)
+        return module["menus"]
+
+    async def set_menu_value(
+        self,
+        module_udid: str,
+        menu_type: str,
+        ido: int,
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Update a menu parameter via the Tech API.
+
+        Args:
+            module_udid: Tech module identifier.
+            menu_type: Menu type (MU, MI, MS, MP).
+            ido: Parameter identifier.
+            data: Payload to send (varies by menu item type).
+
+        Returns:
+            Parsed JSON response from the API.
+
+        """
+        _LOGGER.debug("Setting menu value for %s/%s: %s", menu_type, ido, data)
+        if self.authenticated:
+            path = (
+                f"users/{self.user_id}/modules/{module_udid}"
+                f"/menu/{menu_type}/ido/{ido}"
+            )
+            result = await self.post(path, json.dumps(data))
+            _LOGGER.debug(result)
+        else:
+            raise TechError(401, "Unauthorized")
+        return result
 
     async def get_zone(self, module_udid, zone_id):
         """Return a single zone payload.


### PR DESCRIPTION
## Summary

  This PR implements menu handling support with the following:

  - **Number, select, and switch platforms for menu parameters** — Covers value types (1–5, 106), choice types (11, 111, 112), and on/off type (10).
  - **Button platform for dialogue menu items (type 20)** — Adds support for actions like boiler ignition and extinguishing. Buttons are automatically enabled/disabled based on the current device state via the `access` field, which updates with each coordinator refresh.
  - **Parent group names in entity naming** — Menu entities include their parent group name as a prefix (e.g. "Compressor - On" instead of just "On"), so it's clear what each switch/number/select actually controls.

  All menu data refreshes every 60 seconds through the existing coordinator, same as zones and tiles.

  ## A note on testing

  I only have a pellet boiler (OPOP), so that's the only device I was able to test this on. The button entities for starting and stopping the boiler were something I was really missing, and they work well on my setup. Since this feature covers quite a few new menu item types, I took advantage of Claude Code to help with the implementation, but after reading through it everything seems correct and consistent with the style of the project.

   Would love to hear your thoughts — especially if anyone has a different controller type and could give it a try!

Closes #141