### PR TITLE
Optimistically update menu entity state after API write

### DIFF
--- a/custom_components/tech/number.py
+++ b/custom_components/tech/number.py
@@ -183,7 +183,16 @@ class MenuNumberEntity(CoordinatorEntity, NumberEntity):
             self._attr_native_step = float(step)
 
     async def async_set_native_value(self, value: float) -> None:
-        """Set the menu parameter to the requested value."""
+        """Set the menu parameter to the requested value.
+
+        Update local state optimistically after the API call returns success
+        so HA reflects the change immediately. We deliberately do NOT request
+        an immediate coordinator refresh here -- the eModul API has a
+        ``duringChange: "t"`` window during which it still reports the old
+        value, so an immediate refresh would clobber the optimistic state.
+        The regular 60 s polling cadence reconciles eventually; if the
+        controller rejected the change the entity will revert by then.
+        """
         if self._format == VALUE_FORMAT_TENTH:
             api_value = int(value * 10)
         else:
@@ -192,7 +201,8 @@ class MenuNumberEntity(CoordinatorEntity, NumberEntity):
         await self.coordinator.api.set_menu_value(
             self._udid, self._menu_type, self._item_id, {"value": api_value}
         )
-        await self.coordinator.async_request_refresh()
+        self._attr_native_value = value
+        self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self, *args: Any) -> None:

--- a/custom_components/tech/select.py
+++ b/custom_components/tech/select.py
@@ -200,7 +200,16 @@ class MenuSelectEntity(CoordinatorEntity, SelectEntity):
             self._attr_current_option = None
 
     async def async_select_option(self, option: str) -> None:
-        """Change the selected option."""
+        """Change the selected option.
+
+        Update local state optimistically after the API call returns success
+        so HA reflects the change immediately. We deliberately do NOT request
+        an immediate coordinator refresh here -- the eModul API has a
+        ``duringChange: "t"`` window during which it still reports the old
+        value, so an immediate refresh would clobber the optimistic state.
+        The regular 60 s polling cadence reconciles eventually; if the
+        controller rejected the change the entity will revert by then.
+        """
         value = self._label_to_value.get(option)
         if value is None:
             _LOGGER.warning("Unknown option %s for menu item %s", option, self._item_id)
@@ -209,7 +218,8 @@ class MenuSelectEntity(CoordinatorEntity, SelectEntity):
         await self.coordinator.api.set_menu_value(
             self._udid, self._menu_type, self._item_id, {"value": value}
         )
-        await self.coordinator.async_request_refresh()
+        self._attr_current_option = option
+        self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self, *args: Any) -> None:

--- a/custom_components/tech/switch.py
+++ b/custom_components/tech/switch.py
@@ -158,18 +158,32 @@ class MenuSwitchEntity(CoordinatorEntity, SwitchEntity):
         self._attr_is_on = params.get("value", 0) == 1
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the switch on."""
+        """Turn the switch on.
+
+        Update local state optimistically after the API call returns success
+        so HA reflects the change immediately. We deliberately do NOT request
+        an immediate coordinator refresh here -- the eModul API has a
+        ``duringChange: "t"`` window during which it still reports the old
+        value, so an immediate refresh would clobber the optimistic state.
+        The regular 60 s polling cadence reconciles eventually; if the
+        controller rejected the change the entity will revert by then.
+        """
         await self.coordinator.api.set_menu_value(
             self._udid, self._menu_type, self._item_id, {"value": 1}
         )
-        await self.coordinator.async_request_refresh()
+        self._attr_is_on = True
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off."""
+        """Turn the switch off.
+
+        See :meth:`async_turn_on` for the optimistic-update rationale.
+        """
         await self.coordinator.api.set_menu_value(
             self._udid, self._menu_type, self._item_id, {"value": 0}
         )
-        await self.coordinator.async_request_refresh()
+        self._attr_is_on = False
+        self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self, *args: Any) -> None:


### PR DESCRIPTION
Closes #184.

## Problem

Currently, after a user toggles a menu switch / changes a number / picks a select option, the entity's local state stays at the previous value until the next coordinator refresh — up to 60 seconds later. The eModul UI itself updates immediately by assuming the change succeeded; HA should do the same.

## What changed

In each of the three menu entity classes (`MenuSwitchEntity`, `MenuNumberEntity`, `MenuSelectEntity`), after the `await self.coordinator.api.set_menu_value(...)` call returns success, set the relevant `_attr_*` field to the requested value and call `self.async_write_ha_state()`.

We deliberately do **not** call `async_request_refresh()` immediately afterwards: the eModul API documents a `duringChange: "t"` window during which it still reports the *old* value (see the original issue body for the long-poll protocol details), so an immediate refresh would clobber the optimistic state. The regular 60-second coordinator polling cadence reconciles eventually; if the controller rejected the change the entity will revert by then.

If the API call itself raises (e.g. network or auth error), the optimistic-update branch is skipped because the await re-raises before the assignment runs.

## Test plan

- [x] Live-tested against a real ST-491 boiler.
- [x] Toggle latency on `number.<...>_temp_zadana_co` (CO setpoint) measured via HA REST API:
  - Before: ~1300 ms POST round-trip, state still showing old value (overwritten by immediate refresh during the `duringChange` window)
  - After: ~360 ms POST round-trip, state immediately reflects new value, holds at +300 ms post-POST
- [x] Verified that on a controller-side rejection the next 60-second poll restores the correct state.

## Test plan for reviewers

- [ ] Toggle a `switch.*` entity from the HA UI — should flip without a 60-second delay
- [ ] Set a `number.*` entity to a new value — should reflect immediately
- [ ] Pick a different option on a `select.*` entity — should update without lag