### PR TITLE
Filter deeply-nested menu items by depth

### DIFF
--- a/custom_components/tech/assets.py
+++ b/custom_components/tech/assets.py
@@ -89,6 +89,48 @@ def get_icon_by_type(icon_type: int) -> str:
     return ICON_BY_TYPE.get(icon_type, DEFAULT_ICON)
 
 
+def compute_menu_depths(
+    menus: dict[str, dict[str, Any]],
+) -> dict[str, int]:
+    """Compute the nesting depth of every menu item.
+
+    Depth 0 is a top-level item (``parentId == 0``). Each parent traversal
+    adds one. Used by the menu setup functions in :mod:`switch`, :mod:`number`,
+    :mod:`select` and :mod:`button` to skip deeply-nested items (issue #187)
+    and to drive the ``entity_registry_enabled_default`` decision (issue #189
+    is satisfied because OpenTherm items sit at depth 1-3 and remain
+    registered for users to enable explicitly).
+
+    The traversal is bounded by an internal cycle guard and a hard cap of 20
+    levels so that pathological data cannot hang setup.
+
+    Args:
+        menus: Flat mapping of ``{menu_type}_{item_id}`` to menu item payload.
+
+    Returns:
+        Mapping of the same keys to the integer depth of each item.
+
+    """
+    # Index items by (menuType, id) for O(1) parent lookup.
+    by_key: dict[tuple[str, int], dict[str, Any]] = {
+        (item["menuType"], item["id"]): item for item in menus.values()
+    }
+    depths: dict[str, int] = {}
+    for menu_key, item in menus.items():
+        depth = 0
+        cur = item
+        seen: set[tuple[str, int]] = set()
+        while cur is not None and cur.get("parentId", 0) != 0:
+            cur_key = (cur["menuType"], cur["id"])
+            if cur_key in seen or depth >= 20:
+                break
+            seen.add(cur_key)
+            depth += 1
+            cur = by_key.get((cur["menuType"], cur["parentId"]))
+        depths[menu_key] = depth
+    return depths
+
+
 def build_menu_group_names(
     menus: dict[str, dict[str, Any]],
 ) -> dict[tuple[str, int], str]:

--- a/custom_components/tech/button.py
+++ b/custom_components/tech/button.py
@@ -22,6 +22,8 @@ from .const import (
     DOMAIN,
     INCLUDE_HUB_IN_NAME,
     MANUFACTURER,
+    MENU_DEPTH_DEFAULT_ENABLED_LIMIT,
+    MENU_DEPTH_REGISTRATION_LIMIT,
     MENU_ITEM_TYPE_DIALOGUE,
     UDID,
 )
@@ -51,10 +53,15 @@ async def async_setup_entry(
     zones = await coordinator.api.get_module_zones(controller_udid)
     group_names = assets.build_menu_group_names(menus)
     zone_assignments = assets.build_menu_zone_assignments(menus, zones)
+    depths = assets.compute_menu_depths(menus)
 
     entities: list[MenuButtonEntity] = []
     for key, item in menus.items():
         if item.get("type") != MENU_ITEM_TYPE_DIALOGUE:
+            continue
+        # Skip items deeper than the registration limit -- L-12 has 600+
+        # DIALOGUE items, mostly per-zone "reset to factory" buttons.
+        if depths[key] > MENU_DEPTH_REGISTRATION_LIMIT:
             continue
         entities.append(
             MenuButtonEntity(
@@ -63,6 +70,7 @@ async def async_setup_entry(
                 coordinator,
                 config_entry,
                 group_names,
+                depth=depths[key],
                 zone_id=zone_assignments.get(key),
             )
         )
@@ -83,6 +91,7 @@ class MenuButtonEntity(CoordinatorEntity, ButtonEntity):
         coordinator: TechCoordinator,
         config_entry: ConfigEntry,
         group_names: dict[tuple[str, int], str],
+        depth: int = 0,
         zone_id: int | None = None,
     ) -> None:
         """Initialise a menu button entity.
@@ -93,6 +102,8 @@ class MenuButtonEntity(CoordinatorEntity, ButtonEntity):
             coordinator: Shared Tech data coordinator instance.
             config_entry: Config entry that owns the coordinator.
             group_names: Mapping of ``(menu_type, group_id)`` to group label.
+            depth: Nesting depth of this item in the Tech menu tree
+                (0 = top-level). Drives ``entity_registry_enabled_default``.
             zone_id: Optional zone ID to associate this entity with a zone device.
 
         """
@@ -112,7 +123,7 @@ class MenuButtonEntity(CoordinatorEntity, ButtonEntity):
         )
         self._name = assets.menu_entity_name(item, group_names, prefix)
 
-        self._disabled = item.get("parentId", 0) != 0
+        self._disabled = depth > MENU_DEPTH_DEFAULT_ENABLED_LIMIT
 
         self._update_from_item(item)
 

--- a/custom_components/tech/const.py
+++ b/custom_components/tech/const.py
@@ -125,6 +125,16 @@ MENU_ITEM_TYPE_CHOICE = {11, 111, 112}
 MENU_ITEM_TYPE_DIALOGUE = 20
 MENU_ITEM_TYPE_UNIVERSAL_VALUE = 106
 
+# Menu depth filtering thresholds. Tech menus on multi-zone controllers
+# (notably L-12 with ~4100 MI items) are deeply nested and exposing every
+# leaf as a HA entity produces unusable amounts of registry noise (#187).
+# Items deeper than ``MENU_DEPTH_REGISTRATION_LIMIT`` are not registered as
+# entities at all; items at depth > ``MENU_DEPTH_DEFAULT_ENABLED_LIMIT``
+# are registered but disabled by default so users can opt into the deeper
+# parameters they care about (#189: OpenTherm options live at depth 1-3).
+MENU_DEPTH_REGISTRATION_LIMIT: Final = 3
+MENU_DEPTH_DEFAULT_ENABLED_LIMIT: Final = 1
+
 # Value format types for menu items
 VALUE_FORMAT_NORMAL = 1
 VALUE_FORMAT_TENTH = 2

--- a/custom_components/tech/number.py
+++ b/custom_components/tech/number.py
@@ -22,6 +22,8 @@ from .const import (
     DOMAIN,
     INCLUDE_HUB_IN_NAME,
     MANUFACTURER,
+    MENU_DEPTH_DEFAULT_ENABLED_LIMIT,
+    MENU_DEPTH_REGISTRATION_LIMIT,
     MENU_ITEM_TYPE_UNIVERSAL_VALUE,
     MENU_ITEM_TYPE_VALUE,
     UDID,
@@ -55,6 +57,7 @@ async def async_setup_entry(
     zones = await coordinator.api.get_module_zones(controller_udid)
     group_names = assets.build_menu_group_names(menus)
     zone_assignments = assets.build_menu_zone_assignments(menus, zones)
+    depths = assets.compute_menu_depths(menus)
 
     entities: list[MenuNumberEntity] = []
     for key, item in menus.items():
@@ -63,6 +66,10 @@ async def async_setup_entry(
             continue
         if not item.get("access", False):
             continue
+        # Skip items deeper than the registration limit -- L-12 has 1100+
+        # numeric items, mostly deeply nested per-zone configuration.
+        if depths[key] > MENU_DEPTH_REGISTRATION_LIMIT:
+            continue
         entities.append(
             MenuNumberEntity(
                 item,
@@ -70,6 +77,7 @@ async def async_setup_entry(
                 coordinator,
                 config_entry,
                 group_names,
+                depth=depths[key],
                 zone_id=zone_assignments.get(key),
             )
         )
@@ -90,6 +98,7 @@ class MenuNumberEntity(CoordinatorEntity, NumberEntity):
         coordinator: TechCoordinator,
         config_entry: ConfigEntry,
         group_names: dict[tuple[str, int], str],
+        depth: int = 0,
         zone_id: int | None = None,
     ) -> None:
         """Initialise a menu number entity.
@@ -100,6 +109,8 @@ class MenuNumberEntity(CoordinatorEntity, NumberEntity):
             coordinator: Shared Tech data coordinator instance.
             config_entry: Config entry that owns the coordinator.
             group_names: Mapping of ``(menu_type, group_id)`` to group label.
+            depth: Nesting depth of this item in the Tech menu tree
+                (0 = top-level). Drives ``entity_registry_enabled_default``.
             zone_id: Optional zone ID to associate this entity with a zone device.
 
         """
@@ -124,7 +135,7 @@ class MenuNumberEntity(CoordinatorEntity, NumberEntity):
         )
         self._name = assets.menu_entity_name(item, group_names, prefix)
 
-        self._disabled = item.get("parentId", 0) != 0
+        self._disabled = depth > MENU_DEPTH_DEFAULT_ENABLED_LIMIT
 
         self._update_from_item(item)
 

--- a/custom_components/tech/select.py
+++ b/custom_components/tech/select.py
@@ -22,6 +22,8 @@ from .const import (
     DOMAIN,
     INCLUDE_HUB_IN_NAME,
     MANUFACTURER,
+    MENU_DEPTH_DEFAULT_ENABLED_LIMIT,
+    MENU_DEPTH_REGISTRATION_LIMIT,
     MENU_ITEM_TYPE_CHOICE,
     UDID,
 )
@@ -51,6 +53,7 @@ async def async_setup_entry(
     zones = await coordinator.api.get_module_zones(controller_udid)
     group_names = assets.build_menu_group_names(menus)
     zone_assignments = assets.build_menu_zone_assignments(menus, zones)
+    depths = assets.compute_menu_depths(menus)
 
     entities: list[MenuSelectEntity] = []
     for key, item in menus.items():
@@ -61,6 +64,10 @@ async def async_setup_entry(
         options = item.get("params", {}).get("options", [])
         if not options:
             continue
+        # Skip items deeper than the registration limit -- L-12 has 200+
+        # CHOICE items, mostly per-zone schedule selectors.
+        if depths[key] > MENU_DEPTH_REGISTRATION_LIMIT:
+            continue
         entities.append(
             MenuSelectEntity(
                 item,
@@ -68,6 +75,7 @@ async def async_setup_entry(
                 coordinator,
                 config_entry,
                 group_names,
+                depth=depths[key],
                 zone_id=zone_assignments.get(key),
             )
         )
@@ -88,6 +96,7 @@ class MenuSelectEntity(CoordinatorEntity, SelectEntity):
         coordinator: TechCoordinator,
         config_entry: ConfigEntry,
         group_names: dict[tuple[str, int], str],
+        depth: int = 0,
         zone_id: int | None = None,
     ) -> None:
         """Initialise a menu select entity.
@@ -98,6 +107,8 @@ class MenuSelectEntity(CoordinatorEntity, SelectEntity):
             coordinator: Shared Tech data coordinator instance.
             config_entry: Config entry that owns the coordinator.
             group_names: Mapping of ``(menu_type, group_id)`` to group label.
+            depth: Nesting depth of this item in the Tech menu tree
+                (0 = top-level). Drives ``entity_registry_enabled_default``.
             zone_id: Optional zone ID to associate this entity with a zone device.
 
         """
@@ -117,7 +128,7 @@ class MenuSelectEntity(CoordinatorEntity, SelectEntity):
         )
         self._name = assets.menu_entity_name(item, group_names, prefix)
 
-        self._disabled = item.get("parentId", 0) != 0
+        self._disabled = depth > MENU_DEPTH_DEFAULT_ENABLED_LIMIT
 
         self._value_to_label: dict[int, str] = {}
         self._label_to_value: dict[str, int] = {}

--- a/custom_components/tech/switch.py
+++ b/custom_components/tech/switch.py
@@ -22,6 +22,8 @@ from .const import (
     DOMAIN,
     INCLUDE_HUB_IN_NAME,
     MANUFACTURER,
+    MENU_DEPTH_DEFAULT_ENABLED_LIMIT,
+    MENU_DEPTH_REGISTRATION_LIMIT,
     MENU_ITEM_TYPE_ON_OFF,
     UDID,
 )
@@ -51,12 +53,17 @@ async def async_setup_entry(
     zones = await coordinator.api.get_module_zones(controller_udid)
     group_names = assets.build_menu_group_names(menus)
     zone_assignments = assets.build_menu_zone_assignments(menus, zones)
+    depths = assets.compute_menu_depths(menus)
 
     entities: list[MenuSwitchEntity] = []
     for key, item in menus.items():
         if item.get("type") != MENU_ITEM_TYPE_ON_OFF:
             continue
         if not item.get("access", False):
+            continue
+        # Skip items deeper than the registration limit -- on L-12 there are
+        # 650 ON_OFF items, most of them deep under per-zone subgroups.
+        if depths[key] > MENU_DEPTH_REGISTRATION_LIMIT:
             continue
         entities.append(
             MenuSwitchEntity(
@@ -65,6 +72,7 @@ async def async_setup_entry(
                 coordinator,
                 config_entry,
                 group_names,
+                depth=depths[key],
                 zone_id=zone_assignments.get(key),
             )
         )
@@ -85,6 +93,7 @@ class MenuSwitchEntity(CoordinatorEntity, SwitchEntity):
         coordinator: TechCoordinator,
         config_entry: ConfigEntry,
         group_names: dict[tuple[str, int], str],
+        depth: int = 0,
         zone_id: int | None = None,
     ) -> None:
         """Initialise a menu switch entity.
@@ -95,6 +104,8 @@ class MenuSwitchEntity(CoordinatorEntity, SwitchEntity):
             coordinator: Shared Tech data coordinator instance.
             config_entry: Config entry that owns the coordinator.
             group_names: Mapping of ``(menu_type, group_id)`` to group label.
+            depth: Nesting depth of this item in the Tech menu tree
+                (0 = top-level). Drives ``entity_registry_enabled_default``.
             zone_id: Optional zone ID to associate this entity with a zone device.
 
         """
@@ -114,7 +125,7 @@ class MenuSwitchEntity(CoordinatorEntity, SwitchEntity):
         )
         self._name = assets.menu_entity_name(item, group_names, prefix)
 
-        self._disabled = item.get("parentId", 0) != 0
+        self._disabled = depth > MENU_DEPTH_DEFAULT_ENABLED_LIMIT
 
         self._update_from_item(item)
 


### PR DESCRIPTION
Closes #187 and #189.

## Problem

Multi-zone controllers (notably L-12 with ~4100 MI menu items) emit a deeply nested menu tree. Stock setup registers every `access=true` item as a HA entity, producing >2300 menu-derived entities on a single L-12 module — issue #187 reports a 10× growth after the menu PR landed.

The earlier mitigation (`entity_registry_enabled_default = parentId != 0`) only hides the noise; the registry still grows unbounded, and it also hides legitimate OpenTherm items on L-12 that sit one or two levels deep — issue #189 (`Brak widocznych opcji opentherm L-12`).

## What changed

Add a depth-aware filter:

* **`compute_menu_depths(menus)` in `assets.py`** walks the `parentId` chain for every item and returns its depth (0 = top-level). Bounded by a cycle guard and a hard cap of 20 levels.
* **New constants in `const.py`:**
  * `MENU_DEPTH_REGISTRATION_LIMIT = 3` — items deeper than this are not registered as entities at all.
  * `MENU_DEPTH_DEFAULT_ENABLED_LIMIT = 1` — items deeper than this are registered but disabled by default.
* **The four menu setup functions** (`switch.py`, `number.py`, `select.py`, `button.py`) now drop items with `depth > 3` entirely, and pass each item's depth to its entity constructor.
* **Each menu entity class** uses `depth > 1` to drive `entity_registry_enabled_default`. This replaces the previous `parentId != 0` heuristic, which was too aggressive — every nested item, no matter how shallow, was hidden, including the OpenTherm subtree on L-12.

## Projected entity counts (validated against live data)

| Controller | Registered before | Registered after | Default-enabled |
|---|---|---|---|
| L-12 | 2368 | 146 | 24 |
| ST-491 | 138 | 132 | 74 |

L-12 sees a 94% drop in registered menu entities. ST-491, which doesn't have the deep-menu pathology, is barely affected.

## OpenTherm coverage on L-12 (#189)

The OpenTherm subtree rooted at id `1053` spans depths 1–3. After this PR, all 11 entity-eligible OT items survive registration (verified live):

* `switch ... opentherm_zalaczony` — id 1054, depth 1
* `number ... opentherm_temp_zadana_co` — id 1060, depth 1
* `switch ... sterowanie_pogodowe_zalaczony` — id 1056, depth 2
* `number ... sterowanie_pogodowe_temperatura_min` — id 1058, depth 2
* `number ... sterowanie_pogodowe_temperatura_maks` — id 1059, depth 2
* `select ... ustawienia_cwu_tryb_pracy` — id 1062, depth 2
* `number ... ustawienia_cwu_temperatura_zadana` — id 1068, depth 2
* `number ... ustawienia_cwu_temperatura_obnizenia` — id 1069, depth 2
* `switch ... tryb_czasowy_aktywny` / `tryb_staly_aktywny` — ids 1064/1067, depth 3
* `number ... tryb_czasowy_czas_trwania` — id 1065, depth 3

The depth-1 items (`1054` OT toggle, `1060` CO setpoint) are enabled by default for fresh installs; the deeper ones are registered as disabled and the user can manually enable them.

## Caveat for existing installs

HA preserves entity-registry entries across integration reloads. **Existing installs** that previously registered the full ~2300 entities will see them remain in the registry as orphans (no longer receiving updates), and previously-disabled OT items stay disabled because their registry entry pre-dates this PR's `enabled_default` change.

This is functional but not visually clean. Two ways to address:

1. **Manual cleanup** (recommended): user filters Settings → Entities → "Tech Controllers" → unavailable → bulk-delete.
2. **Re-create the integration**: deletes the registry entries entirely, then re-adds with the new filter.

Adding an opt-in cleanup helper is out of scope for this PR — it carries non-trivial risk of deleting entities users have customised in automations.

## Test plan

- [x] Live-tested against an L-12 (v1.0.16) underfloor controller and an ST-491 (v2.1.9) boiler, single shared eModul account.
- [x] Confirmed the integration registers ~146 menu entities on L-12 instead of ~2400.
- [x] Confirmed all 11 OpenTherm sub-items appear in the registry by entity_id, correctly labelled, and can be enabled via the HA UI.
- [x] Confirmed ST-491 entities essentially unchanged (only depth-4+ items dropped).

## Test plan for reviewers

- [ ] Install on a fresh HA instance against an L-12 module — should see ~150 menu entities, not thousands.
- [ ] Install against an ST-491 / ST-505 — should be visually unchanged from before.
- [ ] On L-12, navigate to Settings → Devices → controller → "+ N disabled entities" and confirm OT items are listed and can be enabled.