### PR TITLE
chore: Change pull request event for autolabeler

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -1,13 +1,6 @@
 name: 'Autolabeler'
 
 on:
-  # pull_request is required for autolabeler
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-  # pull_request_target is required for autolabeler on PRs from forks
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
Updated workflow to use pull_request_target for autolabeling, fixes CI