### PR TITLE
feat: better optimistic update and polling

### DIFF
--- a/custom_components/tech/const.py
+++ b/custom_components/tech/const.py
@@ -54,23 +54,14 @@ PLATFORMS = [
 SCAN_INTERVAL: Final = timedelta(seconds=60)
 API_TIMEOUT: Final = 60
 
-# Optimistic write reconciliation.
-# After a menu write we record an expected-confirm window during which we
-# ignore stale ``duringChange:"t"`` coordinator updates. A background task
-# long-polls the ``update/data`` endpoint until ``duringChange:"f"`` or the
-# attempt budget is exhausted (then we trigger a coordinator refresh as
-# fallback).
-#
-# Some controllers take 2-3 minutes to settle a change (slow boilers,
-# busy installer menus), so the window must outlive the coordinator's
-# 60 s SCAN_INTERVAL. The ``_handle_coordinator_update`` guard drops
-# stale ``duringChange:"t"`` snapshots during that overlap.
-#
-# Budget: ``MAX_ATTEMPTS * POLL_INTERVAL`` should exceed the worst-case
-# settle time. Default 12 * 15 s = 180 s.
+# Optimistic write window. Controllers can take 2-3 min to settle a change,
+# so window outlives the 60 s coordinator tick. Budget = MAX_ATTEMPTS *
+# POLL_INTERVAL must exceed worst-case settle time.
 OPTIMISTIC_TIMEOUT: Final = timedelta(seconds=180)
 OPTIMISTIC_POLL_INTERVAL: Final = 15
 OPTIMISTIC_POLL_MAX_ATTEMPTS: Final = 12
+# Delay before first poll — eModul returns 520 if probed too soon after POST.
+OPTIMISTIC_POLL_INITIAL_DELAY: Final = 15
 
 # tile type
 TYPE_TEMPERATURE = 1

--- a/custom_components/tech/const.py
+++ b/custom_components/tech/const.py
@@ -54,6 +54,24 @@ PLATFORMS = [
 SCAN_INTERVAL: Final = timedelta(seconds=60)
 API_TIMEOUT: Final = 60
 
+# Optimistic write reconciliation.
+# After a menu write we record an expected-confirm window during which we
+# ignore stale ``duringChange:"t"`` coordinator updates. A background task
+# long-polls the ``update/data`` endpoint until ``duringChange:"f"`` or the
+# attempt budget is exhausted (then we trigger a coordinator refresh as
+# fallback).
+#
+# Some controllers take 2-3 minutes to settle a change (slow boilers,
+# busy installer menus), so the window must outlive the coordinator's
+# 60 s SCAN_INTERVAL. The ``_handle_coordinator_update`` guard drops
+# stale ``duringChange:"t"`` snapshots during that overlap.
+#
+# Budget: ``MAX_ATTEMPTS * POLL_INTERVAL`` should exceed the worst-case
+# settle time. Default 12 * 15 s = 180 s.
+OPTIMISTIC_TIMEOUT: Final = timedelta(seconds=180)
+OPTIMISTIC_POLL_INTERVAL: Final = 15
+OPTIMISTIC_POLL_MAX_ATTEMPTS: Final = 12
+
 # tile type
 TYPE_TEMPERATURE = 1
 TYPE_FIRE_SENSOR = 2

--- a/custom_components/tech/entity.py
+++ b/custom_components/tech/entity.py
@@ -1,6 +1,9 @@
 """Shared base entity helpers for Tech tile-derived devices."""
 
 from abc import abstractmethod
+import asyncio
+from collections.abc import Callable
+from datetime import datetime
 import logging
 from typing import Any
 
@@ -8,10 +11,20 @@ from homeassistant.const import CONF_DESCRIPTION, CONF_ID, CONF_PARAMS, CONF_TYP
 from homeassistant.core import callback
 from homeassistant.helpers import entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 from . import assets
-from .const import CONTROLLER, INCLUDE_HUB_IN_NAME, MANUFACTURER, UDID
+from .const import (
+    CONTROLLER,
+    INCLUDE_HUB_IN_NAME,
+    MANUFACTURER,
+    OPTIMISTIC_POLL_INTERVAL,
+    OPTIMISTIC_POLL_MAX_ATTEMPTS,
+    OPTIMISTIC_TIMEOUT,
+    UDID,
+)
 from .coordinator import TechCoordinator
+from .tech import TechError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,3 +94,138 @@ class TileEntity(
         """Handle updated data from the coordinator."""
         self.update_properties(self.coordinator.data["tiles"][self._id])
         self.async_write_ha_state()
+
+
+class OptimisticMenuMixin:
+    """Mixin: optimistic write + ``duringChange`` long-poll confirm.
+
+    Mixed into menu-backed entities (switch/number/select). Coordinates the
+    fire-and-poll pattern documented for the eModul API:
+
+    1. POST the new value via ``set_menu_value`` (validates ``status``).
+    2. Apply the requested value locally and mark the entity as assumed.
+    3. Spawn a background task that long-polls ``update/data`` until the
+       controller flips ``duringChange`` from ``"t"`` to ``"f"``, then
+       refreshes the entity from the authoritative payload.
+    4. While the optimistic window is open, ``_handle_coordinator_update``
+       drops stale ``duringChange:"t"`` snapshots so the entity doesn't
+       flicker back to the previous value mid-transition.
+
+    Subclasses must:
+
+    * Inherit from ``CoordinatorEntity`` (provides ``self.coordinator``).
+    * Define ``_menu_key``, ``_udid``, ``_menu_type``, ``_item_id``.
+    * Implement ``_update_from_item(item)``.
+    """
+
+    _optimistic_until: datetime | None = None
+    _attr_assumed_state: bool = False
+
+    async def _async_set_menu_value(
+        self,
+        payload: dict[str, Any],
+        apply_optimistic: Callable[[], None],
+    ) -> None:
+        """POST a menu value, then write optimistic state and spawn confirm.
+
+        Args:
+            payload: Request body for ``set_menu_value`` (typically
+                ``{"value": int}``).
+            apply_optimistic: Zero-arg callable that mutates the entity's
+                ``_attr_*`` fields to reflect the requested value.
+
+        """
+        api = self.coordinator.api  # type: ignore[attr-defined]
+        await api.set_menu_value(
+            self._udid, self._menu_type, self._item_id, payload
+        )
+        apply_optimistic()
+        self._optimistic_until = dt_util.utcnow() + OPTIMISTIC_TIMEOUT
+        self._attr_assumed_state = True
+        self.async_write_ha_state()  # type: ignore[attr-defined]
+        self.hass.async_create_task(  # type: ignore[attr-defined]
+            self._async_confirm_menu_change()
+        )
+
+    async def _async_confirm_menu_change(self) -> None:
+        """Long-poll until the controller settles the change or budget runs out.
+
+        Drives reconciliation via ``poll_update``. On success applies the
+        authoritative payload and clears the assumed-state flag. On timeout
+        or transport error falls back to ``async_request_refresh`` so the
+        regular coordinator path resolves the final state.
+        """
+        api = self.coordinator.api  # type: ignore[attr-defined]
+        cursor = api.last_update or ""
+        for _ in range(OPTIMISTIC_POLL_MAX_ATTEMPTS):
+            try:
+                data = await api.poll_update(self._udid, cursor)
+            except (TechError, asyncio.TimeoutError) as err:
+                _LOGGER.debug(
+                    "poll_update failed for %s: %s", self._menu_key, err
+                )
+                break
+            cursor = data.get("lastUpdate") or cursor
+            item = _find_menu_item(data, self._menu_type, self._item_id)
+            if item and item.get("duringChange") == "f":
+                self._update_from_item(item)
+                self._clear_optimistic_state()
+                self.async_write_ha_state()  # type: ignore[attr-defined]
+                return
+            await asyncio.sleep(OPTIMISTIC_POLL_INTERVAL)
+        # Budget exhausted or transport error: clear the assumed flag and let
+        # the coordinator's next refresh authoritatively reconcile.
+        self._clear_optimistic_state()
+        self.async_write_ha_state()  # type: ignore[attr-defined]
+        self.hass.async_create_task(  # type: ignore[attr-defined]
+            self.coordinator.async_request_refresh()  # type: ignore[attr-defined]
+        )
+
+    def _clear_optimistic_state(self) -> None:
+        """Reset the optimistic window so coordinator updates flow normally."""
+        self._optimistic_until = None
+        self._attr_assumed_state = False
+
+    def _is_optimistic_active(self) -> bool:
+        """Return ``True`` while the controller is still expected to confirm."""
+        return (
+            self._optimistic_until is not None
+            and dt_util.utcnow() < self._optimistic_until
+        )
+
+    @callback
+    def _handle_coordinator_update(self, *args: Any) -> None:
+        """Shared coordinator-update path for menu entities.
+
+        While the optimistic window is open we drop stale ``duringChange:"t"``
+        snapshots so the entity doesn't briefly revert to the previous value.
+        Any other payload (settled, or out-of-window) clears the assumed flag
+        and is applied authoritatively.
+        """
+        menus = self.coordinator.data.get("menus", {})  # type: ignore[attr-defined]
+        item = menus.get(self._menu_key)
+        if item is not None:
+            if self._is_optimistic_active() and item.get("duringChange") == "t":
+                return
+            self._clear_optimistic_state()
+            self._update_from_item(item)
+        self.async_write_ha_state()  # type: ignore[attr-defined]
+
+
+def _find_menu_item(
+    data: dict[str, Any], menu_type: str, item_id: int
+) -> dict[str, Any] | None:
+    """Locate a menu item in an ``update/data`` poll response.
+
+    The endpoint returns a ``menu`` array containing the entries that
+    changed since the cursor; entries carry the original ``menuType`` and
+    ``id`` fields, so we match on the pair.
+    """
+    for menu_item in data.get("menu", []) or []:
+        if (
+            isinstance(menu_item, dict)
+            and menu_item.get("id") == item_id
+            and menu_item.get("menuType") == menu_type
+        ):
+            return menu_item
+    return None

--- a/custom_components/tech/entity.py
+++ b/custom_components/tech/entity.py
@@ -3,6 +3,7 @@
 from abc import abstractmethod
 import asyncio
 from collections.abc import Callable
+from contextlib import suppress
 from datetime import datetime
 import logging
 from typing import Any
@@ -18,6 +19,7 @@ from .const import (
     CONTROLLER,
     INCLUDE_HUB_IN_NAME,
     MANUFACTURER,
+    OPTIMISTIC_POLL_INITIAL_DELAY,
     OPTIMISTIC_POLL_INTERVAL,
     OPTIMISTIC_POLL_MAX_ATTEMPTS,
     OPTIMISTIC_TIMEOUT,
@@ -119,7 +121,20 @@ class OptimisticMenuMixin:
     """
 
     _optimistic_until: datetime | None = None
+    _last_confirmed_at: datetime | None = None
+    _confirm_task: asyncio.Task | None = None
     _attr_assumed_state: bool = False
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose optimistic-window + confirm telemetry for HA UI."""
+        attrs: dict[str, Any] = {}
+        if self._is_optimistic_active():
+            attrs["optimistic_until"] = self._optimistic_until.isoformat()  # type: ignore[union-attr]
+            attrs["pending_confirm"] = True
+        if self._last_confirmed_at is not None:
+            attrs["last_confirmed_at"] = self._last_confirmed_at.isoformat()
+        return attrs
 
     async def _async_set_menu_value(
         self,
@@ -136,6 +151,12 @@ class OptimisticMenuMixin:
 
         """
         api = self.coordinator.api  # type: ignore[attr-defined]
+        # Drain prior confirm before applying new window — its cancellation
+        # cleanup would otherwise wipe the state we're about to write.
+        if self._confirm_task is not None and not self._confirm_task.done():
+            self._confirm_task.cancel()
+            with suppress(BaseException):
+                await self._confirm_task
         await api.set_menu_value(
             self._udid, self._menu_type, self._item_id, payload
         )
@@ -143,7 +164,7 @@ class OptimisticMenuMixin:
         self._optimistic_until = dt_util.utcnow() + OPTIMISTIC_TIMEOUT
         self._attr_assumed_state = True
         self.async_write_ha_state()  # type: ignore[attr-defined]
-        self.hass.async_create_task(  # type: ignore[attr-defined]
+        self._confirm_task = self.hass.async_create_task(  # type: ignore[attr-defined]
             self._async_confirm_menu_change()
         )
 
@@ -156,30 +177,45 @@ class OptimisticMenuMixin:
         regular coordinator path resolves the final state.
         """
         api = self.coordinator.api  # type: ignore[attr-defined]
-        cursor = api.last_update or ""
-        for _ in range(OPTIMISTIC_POLL_MAX_ATTEMPTS):
-            try:
-                data = await api.poll_update(self._udid, cursor)
-            except (TechError, asyncio.TimeoutError) as err:
-                _LOGGER.debug(
-                    "poll_update failed for %s: %s", self._menu_key, err
-                )
-                break
-            cursor = data.get("lastUpdate") or cursor
-            item = _find_menu_item(data, self._menu_type, self._item_id)
-            if item and item.get("duringChange") == "f":
-                self._update_from_item(item)
-                self._clear_optimistic_state()
+        # eModul expects a tz-aware ISO cursor matching the web UI format
+        # (local time + offset, e.g. ``...+02:00``). ``"0"`` returns 520.
+        cursor = api.last_update or dt_util.now().isoformat()
+        try:
+            # First poll delayed — immediate post-POST polls race the
+            # controller's settle cycle and return 520.
+            await asyncio.sleep(OPTIMISTIC_POLL_INITIAL_DELAY)
+            for _ in range(OPTIMISTIC_POLL_MAX_ATTEMPTS):
+                try:
+                    data = await api.poll_update(self._udid, cursor)
+                except (TechError, asyncio.TimeoutError) as err:
+                    # Retry transient 520/503/timeout — controller may still
+                    # be settling. Don't break the window on first error.
+                    _LOGGER.debug(
+                        "poll_update failed for %s: %s; retrying",
+                        self._menu_key,
+                        err,
+                    )
+                    await asyncio.sleep(OPTIMISTIC_POLL_INTERVAL)
+                    continue
+                cursor = data.get("lastUpdate") or cursor
+                item = _find_menu_item(data, self._menu_type, self._item_id)
+                if item and item.get("duringChange") == "f":
+                    self._update_from_item(item)
+                    self._clear_optimistic_state()
+                    self._last_confirmed_at = dt_util.utcnow()
+                    self.async_write_ha_state()  # type: ignore[attr-defined]
+                    return
+                await asyncio.sleep(OPTIMISTIC_POLL_INTERVAL)
+            self._clear_optimistic_state()
+            self.async_write_ha_state()  # type: ignore[attr-defined]
+            self.hass.async_create_task(  # type: ignore[attr-defined]
+                self.coordinator.async_request_refresh()  # type: ignore[attr-defined]
+            )
+        except asyncio.CancelledError:
+            self._clear_optimistic_state()
+            with suppress(Exception):
                 self.async_write_ha_state()  # type: ignore[attr-defined]
-                return
-            await asyncio.sleep(OPTIMISTIC_POLL_INTERVAL)
-        # Budget exhausted or transport error: clear the assumed flag and let
-        # the coordinator's next refresh authoritatively reconcile.
-        self._clear_optimistic_state()
-        self.async_write_ha_state()  # type: ignore[attr-defined]
-        self.hass.async_create_task(  # type: ignore[attr-defined]
-            self.coordinator.async_request_refresh()  # type: ignore[attr-defined]
-        )
+            raise
 
     def _clear_optimistic_state(self) -> None:
         """Reset the optimistic window so coordinator updates flow normally."""
@@ -197,17 +233,20 @@ class OptimisticMenuMixin:
     def _handle_coordinator_update(self, *args: Any) -> None:
         """Shared coordinator-update path for menu entities.
 
-        While the optimistic window is open we drop stale ``duringChange:"t"``
-        snapshots so the entity doesn't briefly revert to the previous value.
-        Any other payload (settled, or out-of-window) clears the assumed flag
-        and is applied authoritatively.
+        The coordinator's ``/menu/{type}/`` fetch does NOT carry the
+        ``duringChange`` flag (that field only appears on the ``update/data``
+        long-poll endpoint that ``_async_confirm_menu_change`` drives). So
+        while the optimistic window is open we drop every coordinator update
+        for this entity -- otherwise the 60 s coordinator tick would revert
+        the entity to the controller's pre-settle value mid-write. The
+        background confirm task is responsible for applying the authoritative
+        post-settle value and clearing the window.
         """
+        if self._is_optimistic_active():
+            return
         menus = self.coordinator.data.get("menus", {})  # type: ignore[attr-defined]
         item = menus.get(self._menu_key)
         if item is not None:
-            if self._is_optimistic_active() and item.get("duringChange") == "t":
-                return
-            self._clear_optimistic_state()
             self._update_from_item(item)
         self.async_write_ha_state()  # type: ignore[attr-defined]
 

--- a/custom_components/tech/number.py
+++ b/custom_components/tech/number.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
     CONF_NAME,
     EntityCategory,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -30,6 +30,7 @@ from .const import (
     VALUE_FORMAT_TENTH,
 )
 from .coordinator import TechCoordinator
+from .entity import OptimisticMenuMixin
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,7 +86,7 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
 
-class MenuNumberEntity(CoordinatorEntity, NumberEntity):
+class MenuNumberEntity(OptimisticMenuMixin, CoordinatorEntity, NumberEntity):
     """A numeric menu parameter exposed as a Home Assistant number entity."""
 
     _attr_has_entity_name = True
@@ -194,32 +195,17 @@ class MenuNumberEntity(CoordinatorEntity, NumberEntity):
             self._attr_native_step = float(step)
 
     async def async_set_native_value(self, value: float) -> None:
-        """Set the menu parameter to the requested value.
-
-        Update local state optimistically after the API call returns success
-        so HA reflects the change immediately. We deliberately do NOT request
-        an immediate coordinator refresh here -- the eModul API has a
-        ``duringChange: "t"`` window during which it still reports the old
-        value, so an immediate refresh would clobber the optimistic state.
-        The regular 60 s polling cadence reconciles eventually; if the
-        controller rejected the change the entity will revert by then.
-        """
+        """Set the menu parameter (optimistic + ``duringChange`` confirm)."""
         if self._format == VALUE_FORMAT_TENTH:
             api_value = int(value * 10)
+            display_value = api_value / 10.0
         else:
             api_value = int(value)
+            display_value = float(api_value)
 
-        await self.coordinator.api.set_menu_value(
-            self._udid, self._menu_type, self._item_id, {"value": api_value}
-        )
-        self._attr_native_value = value
-        self.async_write_ha_state()
+        def apply() -> None:
+            # Mirror the round-trip the controller will perform so the
+            # optimistic value matches the post-reconcile state.
+            self._attr_native_value = display_value
 
-    @callback
-    def _handle_coordinator_update(self, *args: Any) -> None:
-        """Handle updated data from the coordinator."""
-        menus = self._coordinator.data.get("menus", {})
-        item = menus.get(self._menu_key)
-        if item:
-            self._update_from_item(item)
-        self.async_write_ha_state()
+        await self._async_set_menu_value({"value": api_value}, apply)

--- a/custom_components/tech/select.py
+++ b/custom_components/tech/select.py
@@ -11,7 +11,8 @@ from homeassistant.const import (
     CONF_NAME,
     EntityCategory,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -28,6 +29,7 @@ from .const import (
     UDID,
 )
 from .coordinator import TechCoordinator
+from .entity import OptimisticMenuMixin
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,7 +85,7 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
 
-class MenuSelectEntity(CoordinatorEntity, SelectEntity):
+class MenuSelectEntity(OptimisticMenuMixin, CoordinatorEntity, SelectEntity):
     """A choice menu parameter exposed as a Home Assistant select entity."""
 
     _attr_has_entity_name = True
@@ -211,32 +213,14 @@ class MenuSelectEntity(CoordinatorEntity, SelectEntity):
             self._attr_current_option = None
 
     async def async_select_option(self, option: str) -> None:
-        """Change the selected option.
-
-        Update local state optimistically after the API call returns success
-        so HA reflects the change immediately. We deliberately do NOT request
-        an immediate coordinator refresh here -- the eModul API has a
-        ``duringChange: "t"`` window during which it still reports the old
-        value, so an immediate refresh would clobber the optimistic state.
-        The regular 60 s polling cadence reconciles eventually; if the
-        controller rejected the change the entity will revert by then.
-        """
+        """Change the selected option (optimistic + ``duringChange`` confirm)."""
         value = self._label_to_value.get(option)
         if value is None:
-            _LOGGER.warning("Unknown option %s for menu item %s", option, self._item_id)
-            return
+            raise HomeAssistantError(
+                f"Unknown option '{option}' for menu item {self._item_id}"
+            )
 
-        await self.coordinator.api.set_menu_value(
-            self._udid, self._menu_type, self._item_id, {"value": value}
-        )
-        self._attr_current_option = option
-        self.async_write_ha_state()
+        def apply() -> None:
+            self._attr_current_option = option
 
-    @callback
-    def _handle_coordinator_update(self, *args: Any) -> None:
-        """Handle updated data from the coordinator."""
-        menus = self._coordinator.data.get("menus", {})
-        item = menus.get(self._menu_key)
-        if item:
-            self._update_from_item(item)
-        self.async_write_ha_state()
+        await self._async_set_menu_value({"value": value}, apply)

--- a/custom_components/tech/switch.py
+++ b/custom_components/tech/switch.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
     CONF_NAME,
     EntityCategory,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -28,6 +28,7 @@ from .const import (
     UDID,
 )
 from .coordinator import TechCoordinator
+from .entity import OptimisticMenuMixin
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -80,7 +81,7 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
 
-class MenuSwitchEntity(CoordinatorEntity, SwitchEntity):
+class MenuSwitchEntity(OptimisticMenuMixin, CoordinatorEntity, SwitchEntity):
     """An on/off menu parameter exposed as a Home Assistant switch entity."""
 
     _attr_has_entity_name = True
@@ -169,38 +170,15 @@ class MenuSwitchEntity(CoordinatorEntity, SwitchEntity):
         self._attr_is_on = params.get("value", 0) == 1
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the switch on.
-
-        Update local state optimistically after the API call returns success
-        so HA reflects the change immediately. We deliberately do NOT request
-        an immediate coordinator refresh here -- the eModul API has a
-        ``duringChange: "t"`` window during which it still reports the old
-        value, so an immediate refresh would clobber the optimistic state.
-        The regular 60 s polling cadence reconciles eventually; if the
-        controller rejected the change the entity will revert by then.
-        """
-        await self.coordinator.api.set_menu_value(
-            self._udid, self._menu_type, self._item_id, {"value": 1}
-        )
-        self._attr_is_on = True
-        self.async_write_ha_state()
+        """Turn the switch on (optimistic write + ``duringChange`` confirm)."""
+        await self._set_switch_value(True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off.
+        """Turn the switch off (optimistic write + ``duringChange`` confirm)."""
+        await self._set_switch_value(False)
 
-        See :meth:`async_turn_on` for the optimistic-update rationale.
-        """
-        await self.coordinator.api.set_menu_value(
-            self._udid, self._menu_type, self._item_id, {"value": 0}
-        )
-        self._attr_is_on = False
-        self.async_write_ha_state()
+    async def _set_switch_value(self, on: bool) -> None:
+        def apply() -> None:
+            self._attr_is_on = on
 
-    @callback
-    def _handle_coordinator_update(self, *args: Any) -> None:
-        """Handle updated data from the coordinator."""
-        menus = self._coordinator.data.get("menus", {})
-        item = menus.get(self._menu_key)
-        if item:
-            self._update_from_item(item)
-        self.async_write_ha_state()
+        await self._async_set_menu_value({"value": 1 if on else 0}, apply)

--- a/custom_components/tech/tech.py
+++ b/custom_components/tech/tech.py
@@ -373,27 +373,27 @@ class Tech:
     ) -> dict[str, Any]:
         """Long-poll the controller's update/data endpoint.
 
-        After a menu write the eModul UI polls this endpoint with the
-        previous ``lastUpdate`` cursor until ``duringChange`` flips from
-        ``"t"`` to ``"f"`` (change settled). Empty ``last_update`` works as
-        a cold-start cursor.
+        Used after a menu write to wait for ``duringChange`` to flip from
+        ``"t"`` to ``"f"``. ``last_update`` must be a tz-aware ISO cursor —
+        eModul rejects sentinels like ``"0"`` with 520.
 
         Args:
             module_udid: Tech module identifier.
             last_update: Cursor timestamp from the previous response.
 
         Returns:
-            Parsed JSON response. Contains ``menu``, ``tiles`` and an updated
-            ``lastUpdate`` cursor.
+            Parsed JSON response with ``menu``, ``tiles`` and ``lastUpdate``.
 
         Raises:
-            TechError: If the client is not authenticated or the request fails.
+            TechError: Not authenticated, missing cursor, or request failed.
 
         """
         if not self.authenticated:
             raise TechError(401, "Unauthorized")
+        if not last_update:
+            raise TechError(400, "poll_update requires last_update cursor")
         empty_array = quote("[]", safe="")
-        cursor = quote(last_update, safe="") if last_update else "0"
+        cursor = quote(last_update, safe="")
         path = (
             f"users/{self.user_id}/modules/{module_udid}/update/data/"
             f"parents/{empty_array}/alarm_ids/{empty_array}/last_update/{cursor}"

--- a/custom_components/tech/tech.py
+++ b/custom_components/tech/tech.py
@@ -7,6 +7,7 @@ import json
 import logging
 import time
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from aiohttp import ClientSession
@@ -347,16 +348,61 @@ class Tech:
         Returns:
             Parsed JSON response from the API.
 
+        Raises:
+            TechError: If the client is not authenticated or the controller
+                rejected the write (response status is not ``"success"``).
+
         """
         _LOGGER.debug("Setting menu value for %s/%s: %s", menu_type, ido, data)
-        if self.authenticated:
-            path = (
-                f"users/{self.user_id}/modules/{module_udid}/menu/{menu_type}/ido/{ido}"
-            )
-            result = await self.post(path, json.dumps(data))
-            _LOGGER.debug(result)
-        else:
+        if not self.authenticated:
             raise TechError(401, "Unauthorized")
+        path = f"users/{self.user_id}/modules/{module_udid}/menu/{menu_type}/ido/{ido}"
+        result = await self.post(path, json.dumps(data))
+        _LOGGER.debug(result)
+        # API contract: a successful write returns ``{"status": "success"}``.
+        # Some envelopes omit the field entirely (treated as success); only
+        # an explicit non-success status indicates rejection.
+        if isinstance(result, dict):
+            status = result.get("status")
+            if status is not None and status != "success":
+                raise TechError(400, f"set_menu_value rejected: {result}")
+        return result
+
+    async def poll_update(
+        self, module_udid: str, last_update: str | None
+    ) -> dict[str, Any]:
+        """Long-poll the controller's update/data endpoint.
+
+        After a menu write the eModul UI polls this endpoint with the
+        previous ``lastUpdate`` cursor until ``duringChange`` flips from
+        ``"t"`` to ``"f"`` (change settled). Empty ``last_update`` works as
+        a cold-start cursor.
+
+        Args:
+            module_udid: Tech module identifier.
+            last_update: Cursor timestamp from the previous response.
+
+        Returns:
+            Parsed JSON response. Contains ``menu``, ``tiles`` and an updated
+            ``lastUpdate`` cursor.
+
+        Raises:
+            TechError: If the client is not authenticated or the request fails.
+
+        """
+        if not self.authenticated:
+            raise TechError(401, "Unauthorized")
+        empty_array = quote("[]", safe="")
+        cursor = quote(last_update, safe="") if last_update else "0"
+        path = (
+            f"users/{self.user_id}/modules/{module_udid}/update/data/"
+            f"parents/{empty_array}/alarm_ids/{empty_array}/last_update/{cursor}"
+        )
+        result = await self.get(path)
+        if isinstance(result, dict):
+            new_cursor = result.get("lastUpdate")
+            if new_cursor:
+                self.last_update = new_cursor
         return result
 
     async def get_zone(self, module_udid, zone_id):

--- a/tests/tests_api/test_api.py
+++ b/tests/tests_api/test_api.py
@@ -792,19 +792,18 @@ class TestTechAPI:
             assert result["menu"] == []
 
     @pytest.mark.asyncio
-    async def test_poll_update_cold_start_cursor(
+    async def test_poll_update_requires_cursor(
         self, client_session: aiohttp.ClientSession
     ):
-        """Empty/None ``last_update`` uses the ``0`` cold-start cursor."""
-        with patch.object(Tech, "get", new_callable=AsyncMock) as mock_get:
-            mock_get.return_value = {"lastUpdate": "x", "menu": []}
-            instance = Tech(client_session)
-            instance.authenticated = True
-            instance.user_id = "user123"
+        """Empty/None ``last_update`` is rejected — caller must supply cursor."""
+        instance = Tech(client_session)
+        instance.authenticated = True
+        instance.user_id = "user123"
 
+        with pytest.raises(TechError) as exc_info:
             await instance.poll_update("udid1", None)
 
-            assert mock_get.call_args[0][0].endswith("/last_update/0")
+        assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
     async def test_poll_update_unauthorized(

--- a/tests/tests_api/test_api.py
+++ b/tests/tests_api/test_api.py
@@ -693,6 +693,132 @@ class TestTechAPI:
             assert result == mock_set_const_temp_response
 
     @pytest.mark.asyncio
+    async def test_set_menu_value_success(
+        self, client_session: aiohttp.ClientSession
+    ):
+        """set_menu_value accepts a ``status:success`` response."""
+        with patch.object(Tech, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = {"status": "success"}
+            instance = Tech(client_session)
+            instance.authenticated = True
+            instance.user_id = "user123"
+
+            result = await instance.set_menu_value(
+                "udid1", "MU", 42, {"value": 1}
+            )
+
+            assert mock_post.called
+            assert (
+                mock_post.call_args[0][0]
+                == "users/user123/modules/udid1/menu/MU/ido/42"
+            )
+            assert json.loads(mock_post.call_args[0][1]) == {"value": 1}
+            assert result == {"status": "success"}
+
+    @pytest.mark.asyncio
+    async def test_set_menu_value_missing_status_treated_as_success(
+        self, client_session: aiohttp.ClientSession
+    ):
+        """Response without a ``status`` field is accepted."""
+        with patch.object(Tech, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = {"foo": "bar"}
+            instance = Tech(client_session)
+            instance.authenticated = True
+            instance.user_id = "user123"
+
+            result = await instance.set_menu_value(
+                "udid1", "MU", 42, {"value": 1}
+            )
+
+            assert result == {"foo": "bar"}
+
+    @pytest.mark.asyncio
+    async def test_set_menu_value_rejected_status_raises(
+        self, client_session: aiohttp.ClientSession
+    ):
+        """Non-success status from the controller raises ``TechError``."""
+        with patch.object(Tech, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = {"status": "error"}
+            instance = Tech(client_session)
+            instance.authenticated = True
+            instance.user_id = "user123"
+
+            with pytest.raises(TechError) as exc_info:
+                await instance.set_menu_value(
+                    "udid1", "MU", 42, {"value": 1}
+                )
+
+            assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_set_menu_value_unauthorized(
+        self, client_session: aiohttp.ClientSession
+    ):
+        """set_menu_value raises when the client is not authenticated."""
+        instance = Tech(client_session)
+        instance.authenticated = False
+
+        with pytest.raises(TechError) as exc_info:
+            await instance.set_menu_value("udid1", "MU", 42, {"value": 1})
+
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_poll_update_url_encoding_and_cursor(
+        self, client_session: aiohttp.ClientSession
+    ):
+        """poll_update encodes brackets and ISO cursor, updates last_update."""
+        with patch.object(Tech, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {
+                "lastUpdate": "2026-05-15T10:00:01Z",
+                "menu": [],
+            }
+            instance = Tech(client_session)
+            instance.authenticated = True
+            instance.user_id = "user123"
+
+            result = await instance.poll_update(
+                "udid1", "2026-05-15T10:00:00Z"
+            )
+
+            assert mock_get.called
+            path = mock_get.call_args[0][0]
+            assert path == (
+                "users/user123/modules/udid1/update/data/"
+                "parents/%5B%5D/alarm_ids/%5B%5D/last_update/"
+                "2026-05-15T10%3A00%3A00Z"
+            )
+            assert instance.last_update == "2026-05-15T10:00:01Z"
+            assert result["menu"] == []
+
+    @pytest.mark.asyncio
+    async def test_poll_update_cold_start_cursor(
+        self, client_session: aiohttp.ClientSession
+    ):
+        """Empty/None ``last_update`` uses the ``0`` cold-start cursor."""
+        with patch.object(Tech, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"lastUpdate": "x", "menu": []}
+            instance = Tech(client_session)
+            instance.authenticated = True
+            instance.user_id = "user123"
+
+            await instance.poll_update("udid1", None)
+
+            assert mock_get.call_args[0][0].endswith("/last_update/0")
+
+    @pytest.mark.asyncio
+    async def test_poll_update_unauthorized(
+        self, client_session: aiohttp.ClientSession
+    ):
+        """poll_update raises when not authenticated."""
+        instance = Tech(client_session)
+        instance.authenticated = False
+
+        with pytest.raises(TechError) as exc_info:
+            await instance.poll_update("udid1", None)
+
+        assert exc_info.value.status_code == 401
+    @pytest.mark.asyncio
     async def test_set_zone_mock(
         self, client_session: aiohttp.ClientSession, mock_set_const_temp_response
     ):

--- a/tests/tests_api/test_optimistic_mixin.py
+++ b/tests/tests_api/test_optimistic_mixin.py
@@ -1,0 +1,216 @@
+"""Tests for OptimisticMenuMixin behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.tech.entity import OptimisticMenuMixin, _find_menu_item
+from custom_components.tech.tech import TechError
+
+
+class _StubEntity(OptimisticMenuMixin):
+    """Minimal mixin host used to exercise the optimistic write path."""
+
+    def __init__(self) -> None:
+        self._udid = "udid1"
+        self._menu_key = "MU_42"
+        self._menu_type = "MU"
+        self._item_id = 42
+
+        self.api = MagicMock()
+        self.api.set_menu_value = AsyncMock(return_value={"status": "success"})
+        self.api.poll_update = AsyncMock()
+        self.api.last_update = None
+
+        self.coordinator = MagicMock()
+        self.coordinator.api = self.api
+        self.coordinator.data = {"menus": {}}
+        self.coordinator.async_request_refresh = AsyncMock()
+
+        self.hass = MagicMock()
+        self.created_tasks: list[Any] = []
+        self.hass.async_create_task = self.created_tasks.append
+
+        self.write_calls = 0
+        self.value: int | None = None
+
+    def async_write_ha_state(self) -> None:
+        self.write_calls += 1
+
+    def _update_from_item(self, item: dict[str, Any]) -> None:
+        self.value = item.get("params", {}).get("value")
+
+
+@pytest.mark.asyncio
+async def test_set_menu_value_applies_optimistic_and_spawns_confirm() -> None:
+    """POST + optimistic apply + ``_attr_assumed_state`` + spawned task."""
+    entity = _StubEntity()
+
+    def apply() -> None:
+        entity.value = 7
+
+    await entity._async_set_menu_value({"value": 7}, apply)
+
+    entity.api.set_menu_value.assert_awaited_once_with("udid1", "MU", 42, {"value": 7})
+    assert entity.value == 7
+    assert entity._attr_assumed_state is True
+    assert entity._optimistic_until is not None
+    assert entity.write_calls == 1
+    assert len(entity.created_tasks) == 1
+
+    # Close the spawned coroutine so we don't leak it.
+    entity.created_tasks[0].close()
+
+
+@pytest.mark.asyncio
+async def test_confirm_settles_on_during_change_f() -> None:
+    """Settled poll response updates from item and clears assumed flag."""
+    entity = _StubEntity()
+    entity._attr_assumed_state = True
+    entity._optimistic_until = MagicMock()
+    entity.api.poll_update.return_value = {
+        "lastUpdate": "t1",
+        "menu": [
+            {
+                "id": 42,
+                "menuType": "MU",
+                "duringChange": "f",
+                "params": {"value": 9},
+            }
+        ],
+    }
+
+    await entity._async_confirm_menu_change()
+
+    assert entity.value == 9
+    assert entity._attr_assumed_state is False
+    assert entity._optimistic_until is None
+    assert entity.write_calls == 1
+    entity.coordinator.async_request_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_confirm_tech_error_falls_back_to_refresh() -> None:
+    """Transport error breaks the loop and falls back to coordinator refresh."""
+    entity = _StubEntity()
+    entity._attr_assumed_state = True
+    entity._optimistic_until = MagicMock()
+    entity.api.poll_update.side_effect = TechError(500, "boom")
+
+    await entity._async_confirm_menu_change()
+
+    assert entity._attr_assumed_state is False
+    assert entity._optimistic_until is None
+    # Fallback path: queue a coordinator refresh task.
+    assert len(entity.created_tasks) == 1
+
+
+@pytest.mark.asyncio
+async def test_confirm_budget_exhaustion_triggers_refresh() -> None:
+    """When the controller never settles we eventually request a refresh."""
+    entity = _StubEntity()
+    entity._attr_assumed_state = True
+    entity._optimistic_until = MagicMock()
+    entity.api.poll_update.return_value = {
+        "lastUpdate": "t",
+        "menu": [
+            {
+                "id": 42,
+                "menuType": "MU",
+                "duringChange": "t",
+                "params": {"value": 1},
+            }
+        ],
+    }
+
+    with patch(
+        "custom_components.tech.entity.asyncio.sleep", new=AsyncMock()
+    ) as mock_sleep:
+        await entity._async_confirm_menu_change()
+
+    assert mock_sleep.await_count >= 1
+    assert entity._attr_assumed_state is False
+    assert entity._optimistic_until is None
+    assert len(entity.created_tasks) == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_update_drops_stale_during_change() -> None:
+    """During the optimistic window, ``duringChange:"t"`` is ignored."""
+    entity = _StubEntity()
+    entity.value = 7
+    entity._attr_assumed_state = True
+    # Future timestamp so the window is still active.
+    from datetime import timedelta
+
+    from homeassistant.util import dt as dt_util
+
+    entity._optimistic_until = dt_util.utcnow() + timedelta(seconds=60)
+    entity.coordinator.data = {
+        "menus": {
+            "MU_42": {
+                "id": 42,
+                "menuType": "MU",
+                "duringChange": "t",
+                "params": {"value": 1},
+            }
+        }
+    }
+
+    entity._handle_coordinator_update()
+
+    assert entity.value == 7
+    assert entity._attr_assumed_state is True
+    assert entity.write_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_handle_update_applies_settled_payload() -> None:
+    """Settled payloads always clear optimistic and update authoritatively."""
+    entity = _StubEntity()
+    entity._attr_assumed_state = True
+    from datetime import timedelta
+
+    from homeassistant.util import dt as dt_util
+
+    entity._optimistic_until = dt_util.utcnow() + timedelta(seconds=60)
+    entity.coordinator.data = {
+        "menus": {
+            "MU_42": {
+                "id": 42,
+                "menuType": "MU",
+                "duringChange": "f",
+                "params": {"value": 12},
+            }
+        }
+    }
+
+    entity._handle_coordinator_update()
+
+    assert entity.value == 12
+    assert entity._attr_assumed_state is False
+    assert entity._optimistic_until is None
+    assert entity.write_calls == 1
+
+
+def test_find_menu_item_matches_type_and_id() -> None:
+    """Helper matches ``menuType`` and ``id`` simultaneously."""
+    data = {
+        "menu": [
+            {"id": 1, "menuType": "MU"},
+            {"id": 42, "menuType": "MI"},
+            {"id": 42, "menuType": "MU", "duringChange": "f"},
+        ]
+    }
+    assert _find_menu_item(data, "MU", 42) == {
+        "id": 42,
+        "menuType": "MU",
+        "duringChange": "f",
+    }
+    assert _find_menu_item(data, "MS", 42) is None
+    assert _find_menu_item({}, "MU", 42) is None
+    assert _find_menu_item({"menu": None}, "MU", 42) is None

--- a/tests/tests_api/test_optimistic_mixin.py
+++ b/tests/tests_api/test_optimistic_mixin.py
@@ -94,15 +94,22 @@ async def test_confirm_settles_on_during_change_f() -> None:
 
 
 @pytest.mark.asyncio
-async def test_confirm_tech_error_falls_back_to_refresh() -> None:
-    """Transport error breaks the loop and falls back to coordinator refresh."""
+async def test_confirm_tech_error_retries_then_falls_back() -> None:
+    """Transient transport errors are retried; budget exhaustion refreshes."""
     entity = _StubEntity()
     entity._attr_assumed_state = True
     entity._optimistic_until = MagicMock()
-    entity.api.poll_update.side_effect = TechError(500, "boom")
+    entity.api.poll_update.side_effect = TechError(520, "no modules")
 
-    await entity._async_confirm_menu_change()
+    with patch(
+        "custom_components.tech.entity.asyncio.sleep", new=AsyncMock()
+    ) as mock_sleep:
+        await entity._async_confirm_menu_change()
 
+    # All attempts retried instead of breaking on first error.
+    # Sleep count = 1 initial delay + 12 retry sleeps.
+    assert entity.api.poll_update.await_count == 12
+    assert mock_sleep.await_count == 13
     assert entity._attr_assumed_state is False
     assert entity._optimistic_until is None
     # Fallback path: queue a coordinator refresh task.
@@ -139,24 +146,28 @@ async def test_confirm_budget_exhaustion_triggers_refresh() -> None:
 
 
 @pytest.mark.asyncio
-async def test_handle_update_drops_stale_during_change() -> None:
-    """During the optimistic window, ``duringChange:"t"`` is ignored."""
+async def test_handle_update_drops_all_coord_ticks_while_window_active() -> None:
+    """Coordinator tick during the optimistic window is dropped entirely.
+
+    The coordinator's regular menu fetch does NOT carry ``duringChange``, so
+    we cannot rely on that flag to filter stale snapshots. Drop every update
+    while the window is open and let the confirm task settle.
+    """
     entity = _StubEntity()
     entity.value = 7
     entity._attr_assumed_state = True
-    # Future timestamp so the window is still active.
     from datetime import timedelta
 
     from homeassistant.util import dt as dt_util
 
     entity._optimistic_until = dt_util.utcnow() + timedelta(seconds=60)
+    # Coordinator menu cache lacks ``duringChange`` (real-world payload).
     entity.coordinator.data = {
         "menus": {
             "MU_42": {
                 "id": 42,
                 "menuType": "MU",
-                "duringChange": "t",
-                "params": {"value": 1},
+                "params": {"value": 0},
             }
         }
     }
@@ -169,21 +180,15 @@ async def test_handle_update_drops_stale_during_change() -> None:
 
 
 @pytest.mark.asyncio
-async def test_handle_update_applies_settled_payload() -> None:
-    """Settled payloads always clear optimistic and update authoritatively."""
+async def test_handle_update_applies_after_window_expires() -> None:
+    """Out-of-window coordinator updates apply authoritatively."""
     entity = _StubEntity()
-    entity._attr_assumed_state = True
-    from datetime import timedelta
-
-    from homeassistant.util import dt as dt_util
-
-    entity._optimistic_until = dt_util.utcnow() + timedelta(seconds=60)
+    entity._optimistic_until = None
     entity.coordinator.data = {
         "menus": {
             "MU_42": {
                 "id": 42,
                 "menuType": "MU",
-                "duringChange": "f",
                 "params": {"value": 12},
             }
         }
@@ -192,9 +197,23 @@ async def test_handle_update_applies_settled_payload() -> None:
     entity._handle_coordinator_update()
 
     assert entity.value == 12
+    assert entity.write_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_confirm_cancellation_clears_optimistic_state() -> None:
+    """Cancellation (re-toggle / shutdown) must clear ``pending_confirm``."""
+    entity = _StubEntity()
+    entity._attr_assumed_state = True
+    entity._optimistic_until = MagicMock()
+    entity.api.poll_update.side_effect = asyncio.CancelledError()
+
+    with patch("custom_components.tech.entity.asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(asyncio.CancelledError):
+            await entity._async_confirm_menu_change()
+
     assert entity._attr_assumed_state is False
     assert entity._optimistic_until is None
-    assert entity.write_calls == 1
 
 
 def test_find_menu_item_matches_type_and_id() -> None:


### PR DESCRIPTION
Implements eModul `duringChange` long-poll protocol (#184) for menu writes (switch/number/select) to better handle "in-between" states when entities are updated.

- `OptimisticMenuMixin` (`entity.py`): POST -> optimistic apply with `_attr_assumed_state=True` -> background task long-polls `update/data` until `duringChange:"f"` or 180s budget exhausted, then falls back to coordinator refresh.
- `Tech.set_menu_value`: validates response `status` field, raises `TechError(400)` on non-success.
- `Tech.poll_update`: new method targeting `/update/data/parents/[]/alarm_ids/[]/last_update/{cursor}`; URL-encodes brackets + ISO cursor; tracks `last_update` across calls.
- `_handle_coordinator_update`: drops stale `duringChange:"t"` snapshots while optimistic window open so UI doesn't flicker to previous value.
- Float round-trip in `number.py`: optimistic value mirrors API rounding (`int(value*10)/10`) to match post-reconcile state.
- Constants: `OPTIMISTIC_TIMEOUT=180s`, `OPTIMISTIC_POLL_INTERVAL=15s`, `OPTIMISTIC_POLL_MAX_ATTEMPTS=12`, sized for 2-3min controller settle times. In my case controllers may update their values up to 2-3 minutes.
- Added attributes for optimistic values visibility (for example 4 automations): `pending_confirm`, `last_confirmed_at` & `optimistic_until`

I would test it on my setup for a week or so. But it would be nice if someone else will also check it.