### PR TITLE
fix: fix #195

### DIFF
--- a/custom_components/tech/const.py
+++ b/custom_components/tech/const.py
@@ -143,8 +143,9 @@ WIDGET_TEMPERATURE_CH = 9  # Central-heating temperature reading
 #  * 6   -- enum/mode badge (no numeric meaning -- :func:`_build_widget_tile`
 #           skips these to avoid creating useless "always 0" sensors)
 #  * 7   -- tenths of a degree (the most common boiler temperature unit)
+#  * 8   -- raw percentage (modulation, fan speed, pump duty cycle)
 #  * -1  -- contact widget marker (handled by binary_sensor, not scaled here)
-WIDGET_UNIT_DIVISORS = {0: 1, 4: 10, 5: 100, 6: 1, 7: 10}
+WIDGET_UNIT_DIVISORS = {0: 1, 4: 10, 5: 100, 6: 1, 7: 10, 8: 1}
 
 # ---------------------------------------------------------------------------
 # Icon mapping tables

--- a/custom_components/tech/sensor.py
+++ b/custom_components/tech/sensor.py
@@ -383,7 +383,7 @@ def _build_widget_tile(
         if widget.get("unit") == 6:
             continue
         widget_type = widget.get(CONF_TYPE)
-        if widget_type == WIDGET_COLLECTOR_PUMP:
+        if widget_type == WIDGET_COLLECTOR_PUMP or widget.get("unit") == 8:
             entities.append(
                 TileWidgetPumpSensor(tile, coordinator, config_entry, widget_key)
             )

--- a/tests/fixtures/st2801/module.json
+++ b/tests/fixtures/st2801/module.json
@@ -1,0 +1,230 @@
+{
+  "zones": {
+    "transaction_time": null,
+    "elements": [],
+    "globalSchedules": {
+      "time": null,
+      "duringChange": null,
+      "elements": []
+    },
+    "controllerParameters": {}
+  },
+  "tiles": [
+    {
+      "id": 509,
+      "parentId": 0,
+      "type": 50,
+      "menuId": 0,
+      "orderId": null,
+      "visibility": true,
+      "params": {
+        "description": "Controller software version",
+        "version": "1.2.2",
+        "txtId": 1634,
+        "iconId": 29,
+        "companyId": 6,
+        "controllerName": "ST-2801",
+        "mainControllerId": 0
+      }
+    },
+    {
+      "id": 10024,
+      "parentId": 0,
+      "type": 1,
+      "menuId": 11016,
+      "orderId": 1,
+      "visibility": true,
+      "params": {
+        "description": "Temperature sensor",
+        "workingStatus": true,
+        "txtId": 1072,
+        "value": 230,
+        "batteryLevel": null,
+        "signalStrength": null
+      }
+    },
+    {
+      "id": 10026,
+      "parentId": 0,
+      "type": 1,
+      "menuId": 0,
+      "orderId": 4,
+      "visibility": true,
+      "params": {
+        "description": "Temperature sensor",
+        "workingStatus": true,
+        "txtId": 1071,
+        "value": 370,
+        "batteryLevel": null,
+        "signalStrength": null
+      }
+    },
+    {
+      "id": 10027,
+      "parentId": 0,
+      "type": 1,
+      "menuId": 0,
+      "orderId": 2,
+      "visibility": true,
+      "params": {
+        "description": "Temperature sensor",
+        "workingStatus": true,
+        "txtId": 768,
+        "value": 110,
+        "batteryLevel": null,
+        "signalStrength": null
+      }
+    },
+    {
+      "id": 10128,
+      "parentId": 0,
+      "type": 40,
+      "menuId": 0,
+      "orderId": 10,
+      "visibility": true,
+      "params": {
+        "description": "Text information",
+        "statusId": 598,
+        "headerId": 820,
+        "iconId": 95,
+        "options": []
+      }
+    },
+    {
+      "id": 10130,
+      "parentId": 0,
+      "type": 11,
+      "menuId": 0,
+      "orderId": 6,
+      "visibility": true,
+      "params": {
+        "description": "Relay",
+        "workingStatus": true,
+        "txtId": 575,
+        "iconId": 17
+      }
+    },
+    {
+      "id": 10131,
+      "parentId": 0,
+      "type": 1,
+      "menuId": 11200,
+      "orderId": 13,
+      "visibility": false,
+      "params": {
+        "description": "Temperature sensor",
+        "workingStatus": true,
+        "txtId": 3477,
+        "value": 230,
+        "batteryLevel": null,
+        "signalStrength": null
+      }
+    },
+    {
+      "id": 10132,
+      "parentId": 0,
+      "type": 1,
+      "menuId": 11205,
+      "orderId": 3,
+      "visibility": true,
+      "params": {
+        "description": "Temperature sensor",
+        "workingStatus": true,
+        "txtId": 1070,
+        "value": 230,
+        "batteryLevel": null,
+        "signalStrength": null
+      }
+    },
+    {
+      "id": 10133,
+      "parentId": 0,
+      "type": 41,
+      "menuId": 0,
+      "orderId": 12,
+      "visibility": true,
+      "params": {
+        "description": "Date",
+        "year": 2026,
+        "month": 5,
+        "day": 18,
+        "dayId": 1,
+        "hours": 18,
+        "minutes": 17
+      }
+    },
+    {
+      "id": 10134,
+      "parentId": 0,
+      "type": 2,
+      "menuId": 0,
+      "orderId": 8,
+      "visibility": true,
+      "params": {
+        "description": "Fire sensor",
+        "workingStatus": true,
+        "value": -1
+      }
+    },
+    {
+      "id": 10135,
+      "parentId": 0,
+      "type": 6,
+      "menuId": 0,
+      "orderId": 9,
+      "visibility": true,
+      "params": {
+        "description": "Universal status with widgets",
+        "statusId": 1,
+        "iconId": 206,
+        "widget1": {
+          "txtId": 428,
+          "value": 0,
+          "unit": 8,
+          "type": 1,
+          "params": [0, 0, 0, 0, 0]
+        },
+        "widget2": {
+          "txtId": 609,
+          "value": 14,
+          "unit": 8,
+          "type": 2,
+          "params": [0, 0, 0, 0, 0]
+        }
+      }
+    },
+    {
+      "id": 10136,
+      "parentId": 0,
+      "type": 1,
+      "menuId": 0,
+      "orderId": 5,
+      "visibility": false,
+      "params": {
+        "description": "Temperature sensor",
+        "workingStatus": true,
+        "txtId": 1278,
+        "value": 300,
+        "batteryLevel": null,
+        "signalStrength": null
+      }
+    },
+    {
+      "id": 21202,
+      "parentId": 0,
+      "type": 40,
+      "menuId": 11202,
+      "orderId": 11,
+      "visibility": true,
+      "params": {
+        "description": "Text information",
+        "statusId": 3478,
+        "headerId": 3476,
+        "iconId": 123,
+        "options": []
+      }
+    }
+  ],
+  "tilesOrder": "10024|1,10027|1,10132|1,10026|1,10136|0,10130|1,10134|1,10135|1,10128|1,21202|1,10133|1,10131|0,",
+  "tilesLastUpdate": "2026-05-17 18:17:58.957202+02"
+}

--- a/tests/test_widget_logic.py
+++ b/tests/test_widget_logic.py
@@ -168,7 +168,7 @@ class TestUnitDivisors:
         """Pin the set of known unit codes to detect accidental additions."""
         # Codes outside the table fall back to a divisor of 1 in
         # _build_widget_tile / TileWidgetTemperatureSensor.get_state.
-        assert set(C.WIDGET_UNIT_DIVISORS.keys()) == {0, 4, 5, 6, 7}
+        assert set(C.WIDGET_UNIT_DIVISORS.keys()) == {0, 4, 5, 6, 7, 8}
 
 
 class TestTxtIdFallbacks:
@@ -394,3 +394,114 @@ class TestL12Fixture:
         types = {t["type"] for t in self.module["tiles"]}
         assert 50 in types
         assert 61 in types
+
+
+# ---------------------------------------------------------------------------
+# Fixture-driven assertions: ST-2801 boiler controller
+# ---------------------------------------------------------------------------
+
+
+class TestSt2801Fixture:
+    """Live ST-2801 boiler payload assertions.
+
+    Captured from a boiler running ST-2801 firmware v1.2.2.  Regression test
+    for the burner modulation readout bug (issue #195 upstream) where a
+    unit=8 percentage widget was misclassified as a DHW temperature sensor
+    and displayed as 0 °C instead of 0 %.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        """Load the captured ST-2801 module payload once for the class."""
+        cls.module = _load("st2801/module.json")
+
+    def test_no_zones(self):
+        """ST-2801 boiler exposes no climate zones."""
+        assert self.module["zones"]["elements"] == []
+
+    def test_one_widget_tile(self):
+        """ST-2801 fixture exposes exactly one TYPE_WIDGET tile."""
+        widgets = [t for t in self.module["tiles"] if t["type"] == C.TYPE_WIDGET]
+        assert len(widgets) == 1
+
+    def test_widget_tile_has_two_widgets(self):
+        """The lone TYPE_WIDGET tile carries both widget1 and widget2."""
+        for tile in self.module["tiles"]:
+            if tile["type"] != C.TYPE_WIDGET:
+                continue
+            params = tile["params"]
+            assert "widget1" in params and "widget2" in params
+
+    def test_widget_uses_unit_8_percent(self):
+        """Both widgets in tile 10135 use unit=8 (raw percentage)."""
+        tile = self.module["tiles"][10]  # tile 10135 at index 10
+        assert tile["id"] == 10135
+        assert tile["type"] == C.TYPE_WIDGET
+        assert tile["params"]["widget1"]["unit"] == 8
+        assert tile["params"]["widget2"]["unit"] == 8
+
+    def test_unit_8_widgets_route_to_percentage(self):
+        """Unit=8 widgets must be dispatched to TileWidgetPumpSensor, not
+        TileWidgetTemperatureSensor.
+
+        Before the fix for #195, widget1 (type=1, unit=8, txtId=428
+        "Modulation") fell into the temperature branch and was displayed
+        as 0 °C instead of 0 %.
+        """
+        for tile in self.module["tiles"]:
+            if tile["type"] != C.TYPE_WIDGET:
+                continue
+            for key in ("widget1", "widget2"):
+                w = tile["params"].get(key)
+                if not w or w.get("txtId", 0) == 0:
+                    continue
+                if is_contact_widget_oracle(w):
+                    continue
+                if w.get("unit") == 6:
+                    continue
+                # After the fix, unit=8 is handled like COLLECTOR_PUMP --
+                # it must NOT fall into the temperature branch.
+                if w.get("unit") == 8:
+                    assert w.get("type") in (C.WIDGET_COLLECTOR_PUMP, C.WIDGET_DHW_PUMP), (
+                        f"Unit=8 widget dispatched as temperature: "
+                        f"type={w.get('type')}, txtId={w.get('txtId')}"
+                    )
+
+    def test_widget_dispatch_yields_two_percentage_sensors(self):
+        """Both widget1 and widget2 from tile 10135 survive dispatch."""
+        emitted = 0
+        for tile in self.module["tiles"]:
+            if tile["type"] != C.TYPE_WIDGET:
+                continue
+            for key in ("widget1", "widget2"):
+                w = tile["params"].get(key)
+                if not w or w.get("txtId", 0) == 0:
+                    continue
+                if is_contact_widget_oracle(w):
+                    continue
+                if w.get("unit") == 6:
+                    continue
+                emitted += 1
+        assert emitted == 2
+
+    def test_modulation_value_is_percent(self):
+        """Widget2 modulation value 14 must be a raw percentage (14%)."""
+        tile = self.module["tiles"][10]  # tile 10135
+        w2 = tile["params"]["widget2"]
+        assert w2["value"] == 14
+        assert w2["unit"] == 8
+        # raw percentage -- no scaling needed
+        assert C.WIDGET_UNIT_DIVISORS[8] == 1
+
+    def test_expected_tile_type_distribution(self):
+        """Pin the per-type tile counts of the captured ST-2801 fixture."""
+        counts = Counter(t["type"] for t in self.module["tiles"])
+        assert counts == {
+            C.TYPE_SW_VERSION: 1,
+            C.TYPE_TEMPERATURE: 6,  # 4 visible + 2 hidden
+            C.TYPE_TEXT: 2,
+            C.TYPE_RELAY: 1,
+            C.TYPE_FIRE_SENSOR: 1,
+            C.TYPE_WIDGET: 1,
+            41: 1,  # date tile
+        }


### PR DESCRIPTION
custom_components/tech/const.py:
- Added 8: 1 to WIDGET_UNIT_DIVISORS — unit code 8 means raw percentage (modulation, fan speed, pump duty cycle)

custom_components/tech/sensor.py:
- Changed dispatch in _build_widget_tile: widgets with unit == 8 now route to TileWidgetPumpSensor (percentage) instead of TileWidgetTemperatureSensor (°C). Previously, a burner modulation widget at 14% was displayed as 14°C.

tests/fixtures/st2801/module.json (new):
- 13-tile fixture from ST-2801 v1.2.2 boiler, including the tile-10135 widget tile with both widgets using unit=8

tests/test_widget_logic.py:
- Updated test_known_units_only to include 8
- Added TestSt2801Fixture with 8 tests covering widget dispatch, modulation percentage, and tile type distribution
All 84 tests pass, no regressions on existing ST-491 and L-12 fixtures.

Fixes #195 