### PR TITLE
fix: guard against menu tree cycles in build_menu_zone_assignments

### DIFF
--- a/custom_components/tech/assets.py
+++ b/custom_components/tech/assets.py
@@ -257,8 +257,12 @@ def build_menu_zone_assignments(
     assignments: dict[str, int] = {}
     for sg_id, zone_id in subgroup_to_zone.items():
         queue = [sg_id]
+        visited: set[int] = set()
         while queue:
             parent_id = queue.pop()
+            if parent_id in visited:
+                continue
+            visited.add(parent_id)
             for child_key in all_children.get((mt, parent_id), []):
                 assignments[child_key] = zone_id
                 child_item = menus[child_key]


### PR DESCRIPTION

Fixes #207 

### Problem

On some controllers, setup hangs Home Assistant indefinitely (event loop blocked,
100% CPU) since v2.8.0. The BFS in `build_menu_zone_assignments()` has no cycle
guard, so a menu group that is (directly or indirectly) its own ancestor causes
`while queue` to loop forever, because a group id keeps getting re-appended.

### Fix

Add a `visited` set to the BFS — the same protection that `compute_menu_depths()`
in the same module already uses. Items are processed at most once, so cyclic /
self-referential menu data can no longer hang setup.

### Testing

Reproduced the hang on my controller with 2.8.0/2.8.1 (HA 2026.7, Python 3.14).
With this change the integration sets up correctly and all entities load; 2.7.2
was unaffected because it predates menu handling.